### PR TITLE
Fix plugin's url method

### DIFF
--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -913,7 +913,7 @@ class WP_Piwik {
 	/**
 	 * Get WP-Piwik's URL
 	 */
-	public function getPluginURL() { //hemen
+	public function getPluginURL() {
 		return trailingslashit ( plugin_dir_url( dirname( __FILE__ ) ) );
 	}
 

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -913,8 +913,8 @@ class WP_Piwik {
 	/**
 	 * Get WP-Piwik's URL
 	 */
-	public function getPluginURL() {
-		return trailingslashit ( plugins_url () . '/wp-piwik/' );
+	public function getPluginURL() { //hemen
+		return trailingslashit ( plugin_dir_url( dirname( __FILE__ ) ) );
 	}
 
 	/**


### PR DESCRIPTION
If you use a dynamic folder for the plugin, this is the solution. In my case, "wp-piwik" is not always the name of the plugin's folder.