### PR TITLE
Fix for stalled blog options on network activation

### DIFF
--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -1212,7 +1212,7 @@ class WP_Piwik {
 		if (isset ( $result ['script'] ) && ! empty ( $result ['script'] )) {
 			self::$settings->setOption ( 'tracking_code', $result ['script'], $blogId );
 			self::$settings->setOption ( 'noscript_code', $result ['noscript'], $blogId );
-			self::$settings->setGlobalOption ( 'proxy_url', $result ['proxy'], $blogId );
+			self::$settings->setGlobalOption ( 'proxy_url', $result ['proxy'] );
 		}
 		return $result;
 	}

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -228,12 +228,17 @@ class Settings {
 	 *        	blog ID (default: current blog)
 	 */
 	public function setOption($key, $value, $blogID = null) {
+		if (empty( $blogID )) {
+			$blogID = get_current_blog_id();
+		}
 		$this->settingsChanged = true;
 		self::$wpPiwik->log ( 'Changed option ' . $key . ': ' . $value );
-		if ($this->checkNetworkActivation () && ! empty ( $blogID )) {
+		if ($this->checkNetworkActivation ()) {
 			update_blog_option ( $blogID, 'wp-piwik-'.$key, $value );
 		}
-		$this->settings [$key] = $value;
+		if ($blogID == get_current_blog_id()) {
+			$this->settings [$key] = $value;
+		}
 	}
 
 	/**

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -369,7 +369,7 @@ class Settings {
 		if ($in ['track_mode'] == 'manually' || $in ['track_mode'] == 'disabled') {
 			$value = stripslashes ( $value );
 			if ($this->checkNetworkActivation ())
-				add_site_option ( 'wp-piwik-manually', $value );
+				update_site_option ( 'wp-piwik-manually', $value );
 			return $value;
 		}
 		/*$result = self::$wpPiwik->updateTrackingCode ();

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -222,10 +222,10 @@ class Settings {
 	 *
 	 * @param string $key
 	 *        	option key
-	 * @param int $blogID
-	 *        	blog ID (default: current blog)
 	 * @param string $value
 	 *        	new option value
+	 * @param int $blogID
+	 *        	blog ID (default: current blog)
 	 */
 	public function setOption($key, $value, $blogID = null) {
 		$this->settingsChanged = true;

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -231,9 +231,9 @@ class Settings {
 		$this->settingsChanged = true;
 		self::$wpPiwik->log ( 'Changed option ' . $key . ': ' . $value );
 		if ($this->checkNetworkActivation () && ! empty ( $blogID )) {
-			add_blog_option ( $blogID, 'wp-piwik-'.$key, $value );
-		} else
-			$this->settings [$key] = $value;
+			update_blog_option ( $blogID, 'wp-piwik-'.$key, $value );
+		}
+		$this->settings [$key] = $value;
 	}
 
 	/**


### PR DESCRIPTION
1. When plugin activated on WP network and some blogs have wrong/empty Piwik options (`wp-piwik-site_id` etc) - it's continuously requesting Matomo server via `WP_Piwik::requestPiwikSiteId()` trying to update `site_id`, but blog option saved via `self::$settings->setOption ( 'site_id', $siteId );` is overridden then from `$this->settings` in [Settings::save()](https://github.com/braekling/WP-Matomo/blob/469240aa04b44b833cc97c0d77ec21bda6c6699d/classes/WP_Piwik/Settings.php#L156)
Also, in `TrackingCode::__construct()` it calls `self::$wpPiwik->updateTrackingCode ()` with empty `$siteId` and `$blogId` params
Suggested fix: use `get_current_blog_id()` when `$blogID` is empty and remove `else` and always store local blog options in `$this->settings`, maybe limited by condition like
```php
	public function setOption($key, $value, $blogID = null) {
		if (empty( $blogID )) {
			$blogID = get_current_blog_id();
		}
		$this->settingsChanged = true;
		if ($this->checkNetworkActivation ()) {
			update_blog_option ( $blogID, 'wp-piwik-'.$key, $value );
		}
		if ($blogID == get_current_blog_id()) {
			$this->settings [$key] = $value;
		}
	}
```
to avoid any collisions..
2. Replace `add_blog_option()` with `update_blog_option()` to update existing options
3. Same for `add_site_option()` vs `update_site_option()` in `Settings::prepareTrackingCode()`
4. Fix PHPDoc param order