### PR TITLE
Add support for proxing the official HeatmapSessionRecording plugin.

### DIFF
--- a/proxy/plugins/HeatmapSessionRecording/configs.php
+++ b/proxy/plugins/HeatmapSessionRecording/configs.php
@@ -1,0 +1,20 @@
+<?php
+
+# proxy endpoint to support HeatmapSessionRecording tracker which sends requests to this file
+
+define('MATOMO_PROXY_FROM_ENDPOINT', 1);
+
+$path = 'plugins/HeatmapSessionRecording/configs.php';
+
+# Change directory so that we can include proxy.php without breakage
+
+$newDir = dirname(__FILE__) . '/../../';
+chdir($newDir);
+
+# Include proxy.php to enable proxying for the HeatmapSessionRecording plugin
+
+$file = "proxy.php";
+if (file_exists($file)) {
+    include $file;
+}
+


### PR DESCRIPTION
Add support for proxing the offical HeatmapSessionRecording plugin. 

This patch is just a small wp-adaption of the same file in the official Matomo Tracker Proxy repository:
https://github.com/matomo-org/tracker-proxy/blob/master/plugins/HeatmapSessionRecording/configs.php