### PR TITLE
use global $wp_query->found_posts instead of creating a new WP_Query to count search results in trackSiteSearch mode, for better performance

### DIFF
--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -118,9 +118,9 @@ class TrackingCode {
 	}
 
 	private function applySearchChanges() {
+		global $wp_query;
 		self::$wpPiwik->log ( 'Apply search tracking changes. Blog ID: ' . get_current_blog_id () . ' Site ID: ' . self::$wpPiwik->getOption ( 'site_id' ) );
-		$objSearch = new \WP_Query ( "s=" . get_search_query () . '&showposts=-1' );
-		$intResultCount = $objSearch->post_count;
+		$intResultCount = $wp_query->found_posts;
 		$this->trackingCode = str_replace ( "_paq.push(['trackPageView']);", "_paq.push(['trackSiteSearch','" . get_search_query () . "', false, " . $intResultCount . "]);\n_paq.push(['trackPageView']);", $this->trackingCode );
 	}
 


### PR DESCRIPTION
When "Track search: Use Matomo's advanced Site Search Analytics feature" is selected, an extra/new WP_Query is ran to count the number of results and push them to Matomo. This can **really** slow down searches.

Using the already available global $wp_query object avoids having to run an extra query.