### PR TITLE
SitesManager.addSite API returns {"value":123} array

### DIFF
--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -1152,7 +1152,8 @@ class WP_Piwik {
 				'urls' => $isCurrent ? get_bloginfo ( 'url' ) : get_blog_details ( $blogId )->siteurl,
 				'siteName' => urlencode( $isCurrent ? get_bloginfo ( 'name' ) : get_blog_details ( $blogId )->blogname )
 		) );
-		$result = (int) $this->request ( $id );
+		$result = $this->request ( $id );
+		$result = (int) ( $result['value'] ?? 0 );
 		self::$logger->log ( 'Create Matomo ID: WordPress site ' . ($isCurrent ? get_bloginfo ( 'url' ) : get_blog_details ( $blogId )->siteurl) . ' = Matomo ID ' . $result );
 		if (empty ( $result ))
 			return null;

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -1153,7 +1153,11 @@ class WP_Piwik {
 				'siteName' => urlencode( $isCurrent ? get_bloginfo ( 'name' ) : get_blog_details ( $blogId )->blogname )
 		) );
 		$result = $this->request ( $id );
-		$result = (int) ( $result['value'] ?? 0 );
+		if ( is_array( $result ) && isset( $result['value'] ) ) {
+			$result = (int) $result['value'];
+		} else {
+			$result = (int) $result;
+		}
 		self::$logger->log ( 'Create Matomo ID: WordPress site ' . ($isCurrent ? get_bloginfo ( 'url' ) : get_blog_details ( $blogId )->siteurl) . ' = Matomo ID ' . $result );
 		if (empty ( $result ))
 			return null;


### PR DESCRIPTION
Having same issue https://github.com/braekling/WP-Matomo/issues/107
Found this bug: SitesManager.addSite API returns {"value":123}, so `(int) $result` will be always 1
How to reproduce:
Self-hosted (HTTP API) Matomo, version: 4.13.0:
`https://matomo-install.com/?module=API&method=SitesManager.addSite&siteName=test&urls=https://test.com&format=JSON&token_auth=...`
Response:
`{"value":123}`