### PR TITLE
WBS-1528 Rename plugin to 'Connect Matomo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WP-Matomo (former WP-Piwik)
+# Matomo Connector (former WP-Matomo, WP-Piwik)
 
 This [WordPress](https://wordpress.org) plugin adds a [Matomo](http://matomo.org) stats site to your blog's dashboard. It's also able to add the Matomo tracking code to your blog.
 
@@ -6,4 +6,4 @@ This [WordPress](https://wordpress.org) plugin adds a [Matomo](http://matomo.org
 
 To use this plugin you will need your own Matomo instance. If you do not already have a Matomo setup, you have two simple options: use either [self-hosted](http://matomo.org/) or [cloud-hosted](http://matomo.org/hosting/).
 
-This repository was created to develop and maintain WP-Matomo (WP-Piwik). Please see the WordPress plugin directory if you like to use this plugin: https://wordpress.org/plugins/wp-piwik/
+This repository was created to develop and maintain Matomo Connector (WP-Matomo, WP-Piwik). Please see the WordPress plugin directory if you like to use this plugin: https://wordpress.org/plugins/wp-piwik/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Matomo Connector (former WP-Matomo, WP-Piwik)
+# Connect Matomo (former WP-Matomo, WP-Piwik)
 
 This [WordPress](https://wordpress.org) plugin adds a [Matomo](http://matomo.org) stats site to your blog's dashboard. It's also able to add the Matomo tracking code to your blog.
 
@@ -6,4 +6,4 @@ This [WordPress](https://wordpress.org) plugin adds a [Matomo](http://matomo.org
 
 To use this plugin you will need your own Matomo instance. If you do not already have a Matomo setup, you have two simple options: use either [self-hosted](http://matomo.org/) or [cloud-hosted](http://matomo.org/hosting/).
 
-This repository was created to develop and maintain Matomo Connector (WP-Matomo, WP-Piwik). Please see the WordPress plugin directory if you like to use this plugin: https://wordpress.org/plugins/wp-piwik/
+This repository was created to develop and maintain Connect Matomo (WP-Matomo, WP-Piwik). Please see the WordPress plugin directory if you like to use this plugin: https://wordpress.org/plugins/wp-piwik/

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -3,7 +3,7 @@
 use WP_Piwik\Widget\Post;
 
 /**
- * The main WP-Matomo class configures, registers and manages the plugin
+ * The main Matomo Connector class configures, registers and manages the plugin
  *
  * @author Andr&eacute; Br&auml;kling <webmaster@braekling.de>
  * @package WP_Piwik
@@ -196,7 +196,7 @@ class WP_Piwik {
 	 * Install WP-Piwik for the first time
 	 */
 	private function installPlugin($isUpdate = false) {
-		self::$logger->log ( 'Running WP-Matomo installation' );
+		self::$logger->log ( 'Running Matomo Connector installation' );
 		if (! $isUpdate)
 			$this->addNotice ( 'install', sprintf ( __ ( '%s %s installed.', 'wp-piwik' ), self::$settings->getNotEmptyGlobalOption ( 'plugin_display_name' ), self::$version ), __ ( 'Next you should connect to Matomo', 'wp-piwik' ) );
 		self::$settings->setGlobalOption ( 'revision', self::$revisionId );
@@ -207,7 +207,7 @@ class WP_Piwik {
 	 * Uninstall WP-Piwik
 	 */
 	public function uninstallPlugin() {
-		self::$logger->log ( 'Running WP-Matomo uninstallation' );
+		self::$logger->log ( 'Running Matomo Connector uninstallation' );
 		if (! defined ( 'WP_UNINSTALL_PLUGIN' ))
 			exit ();
 		self::deleteWordPressOption ( 'wp-piwik-notices' );
@@ -218,7 +218,7 @@ class WP_Piwik {
 	 * Update WP-Piwik
 	 */
 	private function updatePlugin() {
-		self::$logger->log ( 'Upgrade WP-Matomo to ' . self::$version );
+		self::$logger->log ( 'Upgrade Matomo Connector to ' . self::$version );
 		$patches = glob ( dirname ( __FILE__ ) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'update' . DIRECTORY_SEPARATOR . '*.php' );
 		$isPatched = false;
 		if (is_array ( $patches )) {
@@ -492,7 +492,7 @@ class WP_Piwik {
 			) );
 			$unique = $this->request ( $id );
 			$url = is_network_admin () ? $this->getSettingsURL () : false;
-			$content = is_network_admin () ? __('Configure WP-Matomo', 'wp-piwik') : '';
+			$content = is_network_admin () ? __('Configure Matomo Connector', 'wp-piwik') : '';
 			// Leave if result array does contain a message instead of valid data
 			if (isset($unique['result']))
 				$content .= '<!-- '.$unique['result'].': '.($unique['message']?$unique['message']:'...').' -->';

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -3,7 +3,7 @@
 use WP_Piwik\Widget\Post;
 
 /**
- * The main Matomo Connector class configures, registers and manages the plugin
+ * The main Connect Matomo class configures, registers and manages the plugin
  *
  * @author Andr&eacute; Br&auml;kling <webmaster@braekling.de>
  * @package WP_Piwik
@@ -196,7 +196,7 @@ class WP_Piwik {
 	 * Install WP-Piwik for the first time
 	 */
 	private function installPlugin($isUpdate = false) {
-		self::$logger->log ( 'Running Matomo Connector installation' );
+		self::$logger->log ( 'Running Connect Matomo installation' );
 		if (! $isUpdate)
 			$this->addNotice ( 'install', sprintf ( __ ( '%s %s installed.', 'wp-piwik' ), self::$settings->getNotEmptyGlobalOption ( 'plugin_display_name' ), self::$version ), __ ( 'Next you should connect to Matomo', 'wp-piwik' ) );
 		self::$settings->setGlobalOption ( 'revision', self::$revisionId );
@@ -207,7 +207,7 @@ class WP_Piwik {
 	 * Uninstall WP-Piwik
 	 */
 	public function uninstallPlugin() {
-		self::$logger->log ( 'Running Matomo Connector uninstallation' );
+		self::$logger->log ( 'Running Connect Matomo uninstallation' );
 		if (! defined ( 'WP_UNINSTALL_PLUGIN' ))
 			exit ();
 		self::deleteWordPressOption ( 'wp-piwik-notices' );
@@ -218,7 +218,7 @@ class WP_Piwik {
 	 * Update WP-Piwik
 	 */
 	private function updatePlugin() {
-		self::$logger->log ( 'Upgrade Matomo Connector to ' . self::$version );
+		self::$logger->log ( 'Upgrade Connect Matomo to ' . self::$version );
 		$patches = glob ( dirname ( __FILE__ ) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'update' . DIRECTORY_SEPARATOR . '*.php' );
 		$isPatched = false;
 		if (is_array ( $patches )) {
@@ -492,7 +492,7 @@ class WP_Piwik {
 			) );
 			$unique = $this->request ( $id );
 			$url = is_network_admin () ? $this->getSettingsURL () : false;
-			$content = is_network_admin () ? __('Configure Matomo Connector', 'wp-piwik') : '';
+			$content = is_network_admin () ? __('Configure WP-Matomo', 'wp-piwik') : '';
 			// Leave if result array does contain a message instead of valid data
 			if (isset($unique['result']))
 				$content .= '<!-- '.$unique['result'].': '.($unique['message']?$unique['message']:'...').' -->';

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -57,7 +57,7 @@ class Settings {
 					'administrator' => true
 			),
 			'perpost_stats' => "disabled",
-			'plugin_display_name' => 'Matomo Connector',
+			'plugin_display_name' => 'Connect Matomo',
 			'piwik_shortcut' => false,
 			'shortcodes' => false,
 			// User settings: Tracking configuration

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -57,7 +57,7 @@ class Settings {
 					'administrator' => true
 			),
 			'perpost_stats' => "disabled",
-			'plugin_display_name' => 'WP-Matomo',
+			'plugin_display_name' => 'Matomo Connector',
 			'piwik_shortcut' => false,
 			'shortcodes' => false,
 			// User settings: Tracking configuration

--- a/languages/wp-piwik.pot
+++ b/languages/wp-piwik.pot
@@ -38,7 +38,7 @@ msgstr ""
 
 #: classes/WP_Piwik.php:499
 msgid "Configure WP-Matomo"
-msgstr "Configure Matomo Connector"
+msgstr "Configure Connect Matomo"
 
 #: classes/WP_Piwik.php:992
 msgid "An error occured"
@@ -62,12 +62,12 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:55
 msgid "Thanks for using WP-Matomo!"
-msgstr "Thanks for using Matomo Connector!"
+msgstr "Thanks for using Connect Matomo!"
 
 #: classes/WP_Piwik/Admin/Settings.php:58
 #, php-format
 msgid "WP-Matomo %s is successfully connected to Matomo %s."
-msgstr "Matomo Connector %s is successfully connected to Matomo %s."
+msgstr "Connect Matomo %s is successfully connected to Matomo %s."
 
 #: classes/WP_Piwik/Admin/Settings.php:58
 #, php-format
@@ -80,7 +80,7 @@ msgid ""
 "You are running a WordPress %s blog network (WPMU). WP-Matomo will handle "
 "your sites as different websites."
 msgstr ""
-"You are running a WordPress %s blog network (WPMU). Matomo Connector will handle "
+"You are running a WordPress %s blog network (WPMU). Connect Matomo will handle "
 "your sites as different websites."
 
 #: classes/WP_Piwik/Admin/Settings.php:62
@@ -89,7 +89,7 @@ msgid ""
 "WP-Matomo %s was not able to connect to Matomo using your configuration. Check "
 "the &raquo;Connect to Matomo&laquo; section below."
 msgstr ""
-"Matomo Connector %s was not able to connect to Matomo using your configuration. Check "
+"Connect Matomo %s was not able to connect to Matomo using your configuration. Check "
 "the &raquo;Connect to Matomo&laquo; section below."
 
 #: classes/WP_Piwik/Admin/Settings.php:64
@@ -98,7 +98,7 @@ msgid ""
 "WP-Matomo %s was not able to connect to Matomo using your configuration. "
 "During connection the following error occured: <br /><code>%s</code>"
 msgstr ""
-"Matomo Connector %s was not able to connect to Matomo using your configuration. "
+"Connect Matomo %s was not able to connect to Matomo using your configuration. "
 "During connection the following error occured: <br /><code>%s</code>"
 
 #: classes/WP_Piwik/Admin/Settings.php:67
@@ -107,7 +107,7 @@ msgid ""
 "WP-Matomo %s has to be connected to Matomo first. Check the &raquo;Connect to "
 "Matomo&laquo; section below."
 msgstr ""
-"Matomo Connector %s has to be connected to Matomo first. Check the &raquo;Connect to "
+"Connect Matomo %s has to be connected to Matomo first. Check the &raquo;Connect to "
 "Matomo&laquo; section below."
 
 #: classes/WP_Piwik/Admin/Settings.php:71
@@ -137,7 +137,7 @@ msgid ""
 "To use this you will need your own Matomo instance. If you do not already "
 "have a Matomo setup, you have two simple options: use either"
 msgstr ""
-"Matomo Connector is a WordPress plugin to show a selection of Matomo stats in your "
+"Connect Matomo is a WordPress plugin to show a selection of Matomo stats in your "
 "WordPress admin dashboard and to add and configure your Matomo tracking code. "
 "To use this you will need your own Matomo instance. If you do not already "
 "have a Matomo setup, you have two simple options: use either"
@@ -159,7 +159,7 @@ msgid ""
 "Neither cURL nor fopen are available. So WP-Matomo can not use the HTTP API "
 "and not connect to InnoCraft Cloud."
 msgstr ""
-"Neither cURL nor fopen are available. So Matomo Connector can not use the HTTP API "
+"Neither cURL nor fopen are available. So Connect Matomo can not use the HTTP API "
 "and not connect to InnoCraft Cloud."
 
 #: classes/WP_Piwik/Admin/Settings.php:109
@@ -182,7 +182,7 @@ msgid ""
 "configurations. WP-Matomo will connect to Matomo using http(s)."
 msgstr ""
 "This is the default option for a self-hosted Matomo and should work for most "
-"configurations. Matomo Connector will connect to Matomo using http(s)."
+"configurations. Connect Matomo will connect to Matomo using http(s)."
 
 #: classes/WP_Piwik/Admin/Settings.php:111
 #: classes/WP_Piwik/Admin/Settings.php:115
@@ -212,7 +212,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:113
 msgid "Disabled (WP-Matomo will not connect to Matomo)"
-msgstr "Disabled (Matomo Connector will not connect to Matomo)"
+msgstr "Disabled (Connect Matomo will not connect to Matomo)"
 
 #: classes/WP_Piwik/Admin/Settings.php:119
 msgid "Matomo URL"
@@ -255,7 +255,7 @@ msgstr ""
 #: classes/WP_Piwik/Admin/Settings.php:122
 #, php-format
 msgid "See %sWP-Matomo FAQ%s."
-msgstr "See %sMatomo ConnectorFAQ%s."
+msgstr "See %sConnect Matomo FAQ%s."
 
 #: classes/WP_Piwik/Admin/Settings.php:127
 msgid "Auto config"
@@ -267,14 +267,14 @@ msgid ""
 "If your blog is not added to Matomo yet, WP-Matomo will add a new site."
 msgstr ""
 "Check this to automatically choose your blog from your Matomo sites by URL. "
-"If your blog is not added to Matomo yet, Matomo Connector will add a new site."
+"If your blog is not added to Matomo yet, Connect Matomo will add a new site."
 
 #: classes/WP_Piwik/Admin/Settings.php:131
 #, php-format
 msgid ""
 "WP-Matomo %s was not able to get sites with at least view access: <br /><code>"
 "%s</code>"
-msgstr "Matomo Connector %s was not able to get sites with at least view access: <br /><code>"
+msgstr "Connect Matomo %s was not able to get sites with at least view access: <br /><code>"
 "%s</code>"
 
 #: classes/WP_Piwik/Admin/Settings.php:141
@@ -359,7 +359,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:172
 msgid "Enable WP-Matomo dashboard widget &quot;Overview&quot;."
-msgstr "Enable Matomo Connector dashboard widget &quot;Overview&quot;."
+msgstr "Enable Connect Matomo dashboard widget &quot;Overview&quot;."
 
 #: classes/WP_Piwik/Admin/Settings.php:174
 msgid "Dashboard graph"
@@ -367,7 +367,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:174
 msgid "Enable WP-Matomo dashboard widget &quot;Graph&quot;."
-msgstr "Enable Matomo Connector dashboard widget &quot;Graph&quot;."
+msgstr "Enable Connect Matomo dashboard widget &quot;Graph&quot;."
 
 #: classes/WP_Piwik/Admin/Settings.php:176
 msgid "Dashboard SEO"
@@ -375,7 +375,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:176
 msgid "Enable WP-Matomo dashboard widget &quot;SEO&quot;."
-msgstr "Enable Matomo Connector dashboard widget &quot;SEO&quot;."
+msgstr "Enable Connect Matomo dashboard widget &quot;SEO&quot;."
 
 #: classes/WP_Piwik/Admin/Settings.php:178
 msgid "Dashboard e-commerce"
@@ -383,7 +383,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:178
 msgid "Enable WP-Matomo dashboard widget &quot;E-commerce&quot;."
-msgstr "Enable Matomo Connector dashboard widget &quot;E-commerce&quot;."
+msgstr "Enable Connect Matomo dashboard widget &quot;E-commerce&quot;."
 
 #: classes/WP_Piwik/Admin/Settings.php:180
 msgid "Show graph on WordPress Toolbar"
@@ -419,7 +419,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:195
 msgid "WP-Matomo display name"
-msgstr "Matomo Connector display name"
+msgstr "Connect Matomo display name"
 
 #: classes/WP_Piwik/Admin/Settings.php:195
 msgid "Plugin name shown in WordPress."
@@ -443,7 +443,7 @@ msgid ""
 "tracking code to your template files or you use another plugin to add the "
 "tracking code."
 msgstr ""
-"Matomo Connector will not add the tracking code. Use this, if you want to add the "
+"Connect Matomo will not add the tracking code. Use this, if you want to add the "
 "tracking code to your template files or you use another plugin to add the "
 "tracking code."
 
@@ -454,7 +454,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:208
 msgid "WP-Matomo will use Matomo's standard tracking code."
-msgstr "Matomo Connector will use Matomo's standard tracking code."
+msgstr "Connect Matomo will use Matomo's standard tracking code."
 
 #: classes/WP_Piwik/Admin/Settings.php:208
 #: classes/WP_Piwik/Admin/Settings.php:212
@@ -599,7 +599,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:238
 msgid "WP-Matomo can automatically add a 404-category to track 404-page-visits."
-msgstr "Matomo Connector can automatically add a 404-category to track 404-page-visits."
+msgstr "Connect Matomo can automatically add a 404-category to track 404-page-visits."
 
 #: classes/WP_Piwik/Admin/Settings.php:241
 msgid "Add annotation on new post of type"
@@ -800,7 +800,7 @@ msgid ""
 "Choose whether WP-Matomo should use cURL or fopen to connect to Matomo in HTTP "
 "or Cloud mode."
 msgstr ""
-"Choose whether Matomo Connector should use cURL or fopen to connect to Matomo in HTTP "
+"Choose whether Connect Matomo should use cURL or fopen to connect to Matomo in HTTP "
 "or Cloud mode."
 
 #: classes/WP_Piwik/Admin/Settings.php:305
@@ -819,7 +819,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:308
 msgid "Choose whether WP-Matomo should use POST or GET in HTTP or Cloud mode."
-msgstr "Choose whether Matomo Connector should use POST or GET in HTTP or Cloud mode."
+msgstr "Choose whether Connect Matomo should use POST or GET in HTTP or Cloud mode."
 
 #: classes/WP_Piwik/Admin/Settings.php:310
 msgid "Disable time limit"
@@ -930,15 +930,15 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:338
 msgid "Show always if WP-Matomo is updated"
-msgstr "Show always if Matomo Connector is updated"
+msgstr "Show always if Connect Matomo is updated"
 
 #: classes/WP_Piwik/Admin/Settings.php:339
 msgid "Show only if WP-Matomo is updated and settings were changed"
-msgstr "Show only if Matomo Connector is updated and settings were changed"
+msgstr "Show only if Connect Matomo is updated and settings were changed"
 
 #: classes/WP_Piwik/Admin/Settings.php:341
 msgid "Choose if you want to get an update notice if WP-Matomo is updated."
-msgstr "Choose if you want to get an update notice if Matomo Connector is updated."
+msgstr "Choose if you want to get an update notice if Connect Matomo is updated."
 
 #: classes/WP_Piwik/Admin/Settings.php:343
 msgid "Define all file types for download tracking"
@@ -983,7 +983,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:511
 msgid "If you like WP-Matomo, you can support its development by a donation:"
-msgstr "If you like Matomo Connector, you can support its development by a donation:"
+msgstr "If you like Connect Matomo, you can support its development by a donation:"
 
 #: classes/WP_Piwik/Admin/Settings.php:530
 msgid "My Amazon.de wishlist"
@@ -1029,7 +1029,7 @@ msgid ""
 "much better."
 msgstr ""
 "Thank you very much, all users who send me mails containing criticism, "
-"commendation, feature requests and bug reports! You help me to make Matomo Connector "
+"commendation, feature requests and bug reports! You help me to make Connect Matomo "
 "much better."
 
 #: classes/WP_Piwik/Admin/Settings.php:565
@@ -1044,7 +1044,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:574
 msgid "WP-Matomo support forum"
-msgstr "Matomo Connector support forum"
+msgstr "Connect Matomo support forum"
 
 #: classes/WP_Piwik/Admin/Settings.php:577
 msgid "Debugging"
@@ -1107,7 +1107,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:601
 msgid "Reset WP-Matomo"
-msgstr "Reset Matomo Connector"
+msgstr "Reset Connect Matomo"
 
 #: classes/WP_Piwik/Admin/Settings.php:603
 msgid "Latest support threads on WordPress.org"

--- a/languages/wp-piwik.pot
+++ b/languages/wp-piwik.pot
@@ -38,7 +38,7 @@ msgstr ""
 
 #: classes/WP_Piwik.php:499
 msgid "Configure WP-Matomo"
-msgstr ""
+msgstr "Configure Matomo Connector"
 
 #: classes/WP_Piwik.php:992
 msgid "An error occured"
@@ -62,12 +62,12 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:55
 msgid "Thanks for using WP-Matomo!"
-msgstr ""
+msgstr "Thanks for using Matomo Connector!"
 
 #: classes/WP_Piwik/Admin/Settings.php:58
 #, php-format
 msgid "WP-Matomo %s is successfully connected to Matomo %s."
-msgstr ""
+msgstr "Matomo Connector %s is successfully connected to Matomo %s."
 
 #: classes/WP_Piwik/Admin/Settings.php:58
 #, php-format
@@ -80,6 +80,8 @@ msgid ""
 "You are running a WordPress %s blog network (WPMU). WP-Matomo will handle "
 "your sites as different websites."
 msgstr ""
+"You are running a WordPress %s blog network (WPMU). Matomo Connector will handle "
+"your sites as different websites."
 
 #: classes/WP_Piwik/Admin/Settings.php:62
 #, php-format
@@ -87,6 +89,8 @@ msgid ""
 "WP-Matomo %s was not able to connect to Matomo using your configuration. Check "
 "the &raquo;Connect to Matomo&laquo; section below."
 msgstr ""
+"Matomo Connector %s was not able to connect to Matomo using your configuration. Check "
+"the &raquo;Connect to Matomo&laquo; section below."
 
 #: classes/WP_Piwik/Admin/Settings.php:64
 #, php-format
@@ -94,6 +98,8 @@ msgid ""
 "WP-Matomo %s was not able to connect to Matomo using your configuration. "
 "During connection the following error occured: <br /><code>%s</code>"
 msgstr ""
+"Matomo Connector %s was not able to connect to Matomo using your configuration. "
+"During connection the following error occured: <br /><code>%s</code>"
 
 #: classes/WP_Piwik/Admin/Settings.php:67
 #, php-format
@@ -101,6 +107,8 @@ msgid ""
 "WP-Matomo %s has to be connected to Matomo first. Check the &raquo;Connect to "
 "Matomo&laquo; section below."
 msgstr ""
+"Matomo Connector %s has to be connected to Matomo first. Check the &raquo;Connect to "
+"Matomo&laquo; section below."
 
 #: classes/WP_Piwik/Admin/Settings.php:71
 msgid "Connect to Matomo"
@@ -129,6 +137,10 @@ msgid ""
 "To use this you will need your own Matomo instance. If you do not already "
 "have a Matomo setup, you have two simple options: use either"
 msgstr ""
+"Matomo Connector is a WordPress plugin to show a selection of Matomo stats in your "
+"WordPress admin dashboard and to add and configure your Matomo tracking code. "
+"To use this you will need your own Matomo instance. If you do not already "
+"have a Matomo setup, you have two simple options: use either"
 
 #: classes/WP_Piwik/Admin/Settings.php:106
 msgid "a self-hosted Matomo"
@@ -147,6 +159,8 @@ msgid ""
 "Neither cURL nor fopen are available. So WP-Matomo can not use the HTTP API "
 "and not connect to InnoCraft Cloud."
 msgstr ""
+"Neither cURL nor fopen are available. So Matomo Connector can not use the HTTP API "
+"and not connect to InnoCraft Cloud."
 
 #: classes/WP_Piwik/Admin/Settings.php:109
 #: classes/WP_Piwik/Template/MetaBoxCustomVars.php:30
@@ -167,6 +181,8 @@ msgid ""
 "This is the default option for a self-hosted Matomo and should work for most "
 "configurations. WP-Matomo will connect to Matomo using http(s)."
 msgstr ""
+"This is the default option for a self-hosted Matomo and should work for most "
+"configurations. Matomo Connector will connect to Matomo using http(s)."
 
 #: classes/WP_Piwik/Admin/Settings.php:111
 #: classes/WP_Piwik/Admin/Settings.php:115
@@ -196,7 +212,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:113
 msgid "Disabled (WP-Matomo will not connect to Matomo)"
-msgstr ""
+msgstr "Disabled (Matomo Connector will not connect to Matomo)"
 
 #: classes/WP_Piwik/Admin/Settings.php:119
 msgid "Matomo URL"
@@ -239,7 +255,7 @@ msgstr ""
 #: classes/WP_Piwik/Admin/Settings.php:122
 #, php-format
 msgid "See %sWP-Matomo FAQ%s."
-msgstr ""
+msgstr "See %sMatomo ConnectorFAQ%s."
 
 #: classes/WP_Piwik/Admin/Settings.php:127
 msgid "Auto config"
@@ -250,13 +266,16 @@ msgid ""
 "Check this to automatically choose your blog from your Matomo sites by URL. "
 "If your blog is not added to Matomo yet, WP-Matomo will add a new site."
 msgstr ""
+"Check this to automatically choose your blog from your Matomo sites by URL. "
+"If your blog is not added to Matomo yet, Matomo Connector will add a new site."
 
 #: classes/WP_Piwik/Admin/Settings.php:131
 #, php-format
 msgid ""
 "WP-Matomo %s was not able to get sites with at least view access: <br /><code>"
 "%s</code>"
-msgstr ""
+msgstr "Matomo Connector %s was not able to get sites with at least view access: <br /><code>"
+"%s</code>"
 
 #: classes/WP_Piwik/Admin/Settings.php:141
 msgid "Determined site"
@@ -340,7 +359,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:172
 msgid "Enable WP-Matomo dashboard widget &quot;Overview&quot;."
-msgstr ""
+msgstr "Enable Matomo Connector dashboard widget &quot;Overview&quot;."
 
 #: classes/WP_Piwik/Admin/Settings.php:174
 msgid "Dashboard graph"
@@ -348,7 +367,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:174
 msgid "Enable WP-Matomo dashboard widget &quot;Graph&quot;."
-msgstr ""
+msgstr "Enable Matomo Connector dashboard widget &quot;Graph&quot;."
 
 #: classes/WP_Piwik/Admin/Settings.php:176
 msgid "Dashboard SEO"
@@ -356,7 +375,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:176
 msgid "Enable WP-Matomo dashboard widget &quot;SEO&quot;."
-msgstr ""
+msgstr "Enable Matomo Connector dashboard widget &quot;SEO&quot;."
 
 #: classes/WP_Piwik/Admin/Settings.php:178
 msgid "Dashboard e-commerce"
@@ -364,7 +383,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:178
 msgid "Enable WP-Matomo dashboard widget &quot;E-commerce&quot;."
-msgstr ""
+msgstr "Enable Matomo Connector dashboard widget &quot;E-commerce&quot;."
 
 #: classes/WP_Piwik/Admin/Settings.php:180
 msgid "Show graph on WordPress Toolbar"
@@ -400,7 +419,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:195
 msgid "WP-Matomo display name"
-msgstr ""
+msgstr "Matomo Connector display name"
 
 #: classes/WP_Piwik/Admin/Settings.php:195
 msgid "Plugin name shown in WordPress."
@@ -424,6 +443,9 @@ msgid ""
 "tracking code to your template files or you use another plugin to add the "
 "tracking code."
 msgstr ""
+"Matomo Connector will not add the tracking code. Use this, if you want to add the "
+"tracking code to your template files or you use another plugin to add the "
+"tracking code."
 
 #: classes/WP_Piwik/Admin/Settings.php:208
 #: classes/WP_Piwik/Admin/Settings.php:211
@@ -432,7 +454,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:208
 msgid "WP-Matomo will use Matomo's standard tracking code."
-msgstr ""
+msgstr "Matomo Connector will use Matomo's standard tracking code."
 
 #: classes/WP_Piwik/Admin/Settings.php:208
 #: classes/WP_Piwik/Admin/Settings.php:212
@@ -577,7 +599,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:238
 msgid "WP-Matomo can automatically add a 404-category to track 404-page-visits."
-msgstr ""
+msgstr "Matomo Connector can automatically add a 404-category to track 404-page-visits."
 
 #: classes/WP_Piwik/Admin/Settings.php:241
 msgid "Add annotation on new post of type"
@@ -778,6 +800,8 @@ msgid ""
 "Choose whether WP-Matomo should use cURL or fopen to connect to Matomo in HTTP "
 "or Cloud mode."
 msgstr ""
+"Choose whether Matomo Connector should use cURL or fopen to connect to Matomo in HTTP "
+"or Cloud mode."
 
 #: classes/WP_Piwik/Admin/Settings.php:305
 msgid "HTTP method"
@@ -795,7 +819,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:308
 msgid "Choose whether WP-Matomo should use POST or GET in HTTP or Cloud mode."
-msgstr ""
+msgstr "Choose whether Matomo Connector should use POST or GET in HTTP or Cloud mode."
 
 #: classes/WP_Piwik/Admin/Settings.php:310
 msgid "Disable time limit"
@@ -906,15 +930,15 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:338
 msgid "Show always if WP-Matomo is updated"
-msgstr ""
+msgstr "Show always if Matomo Connector is updated"
 
 #: classes/WP_Piwik/Admin/Settings.php:339
 msgid "Show only if WP-Matomo is updated and settings were changed"
-msgstr ""
+msgstr "Show only if Matomo Connector is updated and settings were changed"
 
 #: classes/WP_Piwik/Admin/Settings.php:341
 msgid "Choose if you want to get an update notice if WP-Matomo is updated."
-msgstr ""
+msgstr "Choose if you want to get an update notice if Matomo Connector is updated."
 
 #: classes/WP_Piwik/Admin/Settings.php:343
 msgid "Define all file types for download tracking"
@@ -959,7 +983,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:511
 msgid "If you like WP-Matomo, you can support its development by a donation:"
-msgstr ""
+msgstr "If you like Matomo Connector, you can support its development by a donation:"
 
 #: classes/WP_Piwik/Admin/Settings.php:530
 msgid "My Amazon.de wishlist"
@@ -1004,6 +1028,9 @@ msgid ""
 "commendation, feature requests and bug reports! You help me to make WP-Matomo "
 "much better."
 msgstr ""
+"Thank you very much, all users who send me mails containing criticism, "
+"commendation, feature requests and bug reports! You help me to make Matomo Connector "
+"much better."
 
 #: classes/WP_Piwik/Admin/Settings.php:565
 msgid ""
@@ -1017,7 +1044,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:574
 msgid "WP-Matomo support forum"
-msgstr ""
+msgstr "Matomo Connector support forum"
 
 #: classes/WP_Piwik/Admin/Settings.php:577
 msgid "Debugging"
@@ -1080,7 +1107,7 @@ msgstr ""
 
 #: classes/WP_Piwik/Admin/Settings.php:601
 msgid "Reset WP-Matomo"
-msgstr ""
+msgstr "Reset Matomo Connector"
 
 #: classes/WP_Piwik/Admin/Settings.php:603
 msgid "Latest support threads on WordPress.org"

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Matomo Connector (WP-Matomo, WP-Piwik) ===
+=== Connect Matomo (WP-Matomo, WP-Piwik) ===
 
 Contributors: Braekling
 Requires at least: 5.0

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WP-Matomo Integration (WP-Piwik) ===
+=== Matomo Connector (WP-Matomo, WP-Piwik) ===
 
 Contributors: Braekling
 Requires at least: 5.0

--- a/update/2023052301.php
+++ b/update/2023052301.php
@@ -1,4 +1,4 @@
 <?php
 
-self::$settings->setGlobalOption('plugin_display_name', "Matomo Connector");
+self::$settings->setGlobalOption('plugin_display_name', "Connect Matomo");
 self::$settings->save ();

--- a/update/2023052301.php
+++ b/update/2023052301.php
@@ -1,0 +1,4 @@
+<?php
+
+self::$settings->setGlobalOption('plugin_display_name', "Matomo Connector");
+self::$settings->save ();

--- a/wp-piwik.php
+++ b/wp-piwik.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: WP-Matomo Integration 
+Plugin Name: Matomo Connector
 
 Plugin URI: http://wordpress.org/extend/plugins/wp-piwik/
 

--- a/wp-piwik.php
+++ b/wp-piwik.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Matomo Connector
+Plugin Name: Connect Matomo
 
 Plugin URI: http://wordpress.org/extend/plugins/wp-piwik/
 


### PR DESCRIPTION
Hello @braekling 

As you previously discussed with Matthieu A., the aim of this PR is to rename this plugin.

I've 
- updated the plugin in DB with your configuration option
- update the POT file

But it remains a lot of WP-PIWIK in your po (and mo) files. I couldn't find any usage of these sentences in your code. 
So I'm not quite sure how do you manage the plugin translations. Maybe you could clarify, please? I may have to update these po files before you do a review.
Let me know.

Kind regards

Mat 