### PR TITLE
new feature to track AI bot requests to Matomo

### DIFF
--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -10,7 +10,15 @@ use WP_Piwik\Widget\Post;
  */
 class WP_Piwik {
 
-	private static $revisionId = 2023092201, $version = '1.0.31', $blog_id, $pluginBasename = NULL, $logger, $settings, $request, $optionsPageId;
+	private static $revisionId = 2023092201;
+	private static $version = '1.0.31';
+	private static $blog_id;
+	private static $pluginBasename = NULL;
+	private static $logger;
+	private static $settings;
+	private static $request;
+	private static $optionsPageId;
+
     public $statsPageId;
 
     /**
@@ -19,12 +27,17 @@ class WP_Piwik {
 	public function __construct() {
 		global $blog_id;
 		self::$blog_id = (isset ( $blog_id ) ? $blog_id : 'n/a');
-		$this->openLogger ();
-		$this->openSettings ();
-		$this->setup ();
-		$this->addFilters ();
-		$this->addActions ();
-		$this->addShortcodes ();
+		$this->openLogger();
+		$this->openSettings();
+		$this->setup();
+		$this->addFilters();
+		$this->addActions();
+		$this->addShortcodes();
+		$this->setUpAiBotTracking();
+	}
+
+	public static function getSettings() {
+		return self::$settings;
 	}
 
 	/**
@@ -825,16 +838,11 @@ class WP_Piwik {
 	 * Start chosen logging method
 	 */
 	private function openLogger() {
-		switch (WP_PIWIK_ACTIVATE_LOGGER) {
-			case 1 :
-				self::$logger = new WP_Piwik\Logger\Screen ( __CLASS__ );
-				break;
-			case 2 :
-				self::$logger = new WP_Piwik\Logger\File ( __CLASS__ );
-				break;
-			default :
-				self::$logger = new WP_Piwik\Logger\Dummy ( __CLASS__ );
-		}
+		self::$logger = \WP_Piwik\Logger::makeLogger();
+	}
+
+	public static function getLogger() {
+		return self::$logger;
 	}
 
 	/**
@@ -1360,5 +1368,10 @@ class WP_Piwik {
 	 */
 	public static function isValidOptionsPost() {
 		return is_admin() && check_admin_referer( 'wp-piwik_settings' ) && current_user_can( 'manage_options' ) ;
+	}
+
+	private function setUpAiBotTracking() {
+		$aiBotTracking = new \WP_Piwik\AIBotTracking( self::$settings, self::$logger );
+		$aiBotTracking->registerHooks();
 	}
 }

--- a/classes/WP_Piwik/AIBotTracking.php
+++ b/classes/WP_Piwik/AIBotTracking.php
@@ -83,7 +83,11 @@ class AIBotTracking {
 		}
 	}
 
-	public function doAiBotTracking() {
+	/**
+	 * @param string|null $url
+	 * @return void
+	 */
+	public function doAiBotTracking( $url = null ) {
 		// track AI bots only once per request
 		if ( self::$aiBotTracked ) {
 			return;
@@ -97,7 +101,7 @@ class AIBotTracking {
 			$is_using_esi_to_track
 			&& empty( $GLOBALS['MATOMO_IN_AI_ESI'] )
 		) {
-			$track_script_url = plugins_url( '/misc/track_ai_bot.php', WP_PIWIK_FILE ) . '?mtm_esi=1';
+			$track_script_url = plugins_url( '/misc/track_ai_bot.php', WP_PIWIK_FILE ) . '?mtm_esi=1&mtm_url=' . rawurlencode( AjaxTracker::getCurrentUrl() );
 			echo '<esi:include src="' . esc_attr( $track_script_url ) . '" cache-control="no-cache" />';
 			return;
 		}
@@ -109,6 +113,7 @@ class AIBotTracking {
 		$responseCode     = http_response_code();
 		$requestElapsedMs = null;
 
+		// cannot track request time if executed via an esi:include
 		if ( empty( $GLOBALS['MATOMO_IN_AI_ESI'] ) ) {
 			$requestElapsedMs = (int) ( timer_float() * 1000 );
 		}
@@ -119,6 +124,12 @@ class AIBotTracking {
 
 		// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 		$source = 'wordpress';
+
+		if ( empty( $url ) ) {
+			$url = AjaxTracker::getCurrentUrl();
+		}
+
+		$this->tracker->setUrl( $url );
 
 		// cannot count bytes echo'd so no response size tracked
 		$this->tracker->doTrackPageViewIfAIBot( $responseCode, null, $requestElapsedMs, $source );

--- a/classes/WP_Piwik/AIBotTracking.php
+++ b/classes/WP_Piwik/AIBotTracking.php
@@ -114,8 +114,11 @@ class AIBotTracking {
 		$requestElapsedMs = null;
 
 		// cannot track request time if executed via an esi:include
-		if ( empty( $GLOBALS['MATOMO_IN_AI_ESI'] ) ) {
-			$requestElapsedMs = (int) ( timer_float() * 1000 );
+		if (
+			empty( $GLOBALS['MATOMO_IN_AI_ESI'] )
+			&& array_key_exists( 'REQUEST_TIME_FLOAT', $_SERVER )
+		) {
+			$requestElapsedMs = (int) ( ( microtime( true ) - $_SERVER['REQUEST_TIME_FLOAT'] ) * 1000 );
 		}
 
 		if ( empty( $responseCode ) ) {
@@ -177,10 +180,6 @@ class AIBotTracking {
 
 		$extension = pathinfo( $requestPath, PATHINFO_EXTENSION );
 		return ! in_array( $extension, self::$extensionsToTrack, true );
-	}
-
-	public static function setIsAiBotTracked($is_tracked ) {
-		self::$aiBotTracked = $is_tracked;
 	}
 
 	public function isJsExecutionDetected() {

--- a/classes/WP_Piwik/AIBotTracking.php
+++ b/classes/WP_Piwik/AIBotTracking.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+namespace WP_Piwik;
+
+use LiteSpeed\ESI;
+
+/**
+ * Performs server side tracking for AI bots.
+ *
+ * Normal server side tracking: when no caching plugins or CDNs are being
+ * used, this class will send tracking requests in the wp_footer hook.
+ *
+ * When advanced-cache.php is used: when a caching plugin creates an
+ * advanced-cache.php file that WordPress uses, tracking must be done
+ * through the standalone script in misc/track_ai_bot.php. This script
+ * must be manually added to a user's wp-config.php file, right after
+ * ABSPATH is defined.
+ *
+ * When .htaccess is used: when a caching plugin modifies the .htaccess
+ * to serve cached files directly, AI bot tracking is not possible.
+ *
+ * When a CDN is used: when a CDN is used to serve cached content, AI
+ * bot tracking can be accomplished through the use of ESI (Edge Side Includes).
+ * In this case, this class outputs an `<esi:include>` directive that
+ * loads the misc/track_ai_bot.php script. This technique will only work
+ * for CDNs that support ESI.
+ *
+ * The misc/track_ai_bot.php script uses this class without all of WordPress loaded.
+ * It can also be loaded outside of WordPress. Because of this, it is important
+ * that the script and this class use as few total dependencies as possible. Otherwise,
+ * AI bot tracking reduce the performance of requests to cached content.
+ */
+
+class AIBotTracking {
+
+	private static $aiBotTracked = false;
+
+	private static $extensionsToTrack = [
+		'', // no extension
+
+		'htm',
+		'html',
+		'php',
+	];
+
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
+	 * @var AjaxTracker
+	 */
+	private $tracker;
+
+	/**
+	 * @param Settings $settings
+	 * @param Logger   $logger
+	 */
+	public function __construct( Settings $settings, Logger $logger ) {
+		$this->settings = $settings;
+		$this->tracker  = new AjaxTracker( $settings, $logger );
+		$this->tracker->setRequestTimeout( 1 );
+	}
+
+	public function registerHooks() {
+		add_action( 'litespeed_init', [ $this, 'litespeedInit' ] );
+		add_action( 'wp_footer', [ $this, 'doAiBotTracking'], 999999 );
+	}
+
+	public function litespeedInit() {
+		if ( class_exists( ESI::class )
+			&& $this->settings->isAiBotTrackingEnabledViaEsiIncludes()
+		) {
+			ESI::set_has_esi();
+		}
+	}
+
+	public function doAiBotTracking() {
+		// track AI bots only once per request
+		if ( self::$aiBotTracked ) {
+			return;
+		}
+
+		self::$aiBotTracked = true;
+
+		// if using ESI to track, and not within the track_ai_bot.php script, output the appropriate ESI tag
+		$is_using_esi_to_track = $this->settings->isAiBotTrackingEnabledViaEsiIncludes();
+		if (
+			$is_using_esi_to_track
+			&& empty( $GLOBALS['MATOMO_IN_AI_ESI'] )
+		) {
+			$track_script_url = plugins_url( '/misc/track_ai_bot.php', WP_PIWIK_FILE ) . '?mtm_esi=1';
+			echo '<esi:include src="' . esc_attr( $track_script_url ) . '" cache-control="no-cache" />';
+			return;
+		}
+
+		if ( ! $this->isDoingAiBotTrackingThisRequest() ) {
+			return;
+		}
+
+		$responseCode     = http_response_code();
+		$requestElapsedMs = null;
+
+		if ( empty( $GLOBALS['MATOMO_IN_AI_ESI'] ) ) {
+			$requestElapsedMs = (int) ( timer_float() * 1000 );
+		}
+
+		if ( empty( $responseCode ) ) {
+			$responseCode = 200;
+		}
+
+		// phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+		$source = 'wordpress';
+
+		// cannot count bytes echo'd so no response size tracked
+		$this->tracker->doTrackPageViewIfAIBot( $responseCode, null, $requestElapsedMs, $source );
+	}
+
+	public function shouldTrackCurrentPage() {
+		if ( is_admin() ) {
+			return false;
+		}
+
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return false;
+		}
+
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return false;
+		}
+
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$requestPath = (string) wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH );
+
+		if ( preg_match( '/matomo\.php$/', $requestPath ) ) {
+			return false;
+		}
+
+		if ( $this->isRequestForFile( $requestPath ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private function isRequestForFile( $requestPath ) {
+		if (
+			! empty( $_SERVER['DOCUMENT_ROOT'] )
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			&& is_dir( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) . $requestPath )
+		) {
+			return false;
+		}
+
+		$extension = pathinfo( $requestPath, PATHINFO_EXTENSION );
+		return ! in_array( $extension, self::$extensionsToTrack, true );
+	}
+
+	public static function setIsAiBotTracked($is_tracked ) {
+		self::$aiBotTracked = $is_tracked;
+	}
+
+	public function isJsExecutionDetected() {
+		return ! empty( $_COOKIE['matomo_has_js'] )
+			&& '1' === $_COOKIE['matomo_has_js'];
+	}
+
+	private function isDoingAiBotTrackingThisRequest() {
+		if ( ! empty( $GLOBALS['MATOMO_IN_AI_ESI'] ) ) {
+			return true;
+		}
+
+		if ( ! $this->shouldTrackCurrentPage() ) {
+			return false;
+		}
+
+		if ( $this->isJsExecutionDetected() ) {
+			return false;
+		}
+
+		if ( ! AjaxTracker::isUserAgentAIBot( $this->tracker->userAgent ) ) {
+			return false;
+		}
+
+		if (
+			! $this->settings->isAiBotTrackingEnabled()
+			|| ! $this->settings->isTrackingEnabled()
+		) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -974,7 +974,7 @@ class Settings extends \WP_Piwik\Admin {
 			return false; // not using apache
 		}
 
-		$htaccessContents     = file_get_contents( ABSPATH . '/.htaccess' );
+		$htaccessContents   = file_get_contents( ABSPATH . '/.htaccess' );
 		$isRewriteRuleFound = preg_match( '%RewriteRule.*?/wp-content/cache/%', $htaccessContents ) === 1;
 
 		return $isRewriteRuleFound;

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -324,6 +324,110 @@ class Settings extends \WP_Piwik\Admin {
 				'displayname' => __ ( 'Display Name (Not Recommended!)', 'wp-piwik' )
 		), __ ( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'wp-piwik' ), '', $isNotTracking, $fullGeneratedTrackingGroup );
 
+		?>
+		<tr class="<?= $isNotTracking ? 'hidden' : ''?> <?= $fullGeneratedTrackingGroup ?> wp-piwik-track-option-manually">
+			<td><h4><?php esc_html_e( 'AI Bot Tracking', 'wp-piwik' ); ?></h4></td>
+		</tr>
+		<?php
+
+		$this->showCheckbox(
+			\WP_Piwik\Settings::TRACK_AI_BOTS,
+			esc_html__( 'Track AI Bots', 'wp-piwik' ),
+			esc_html__( 'If enabled, AI bots will trigger page views even if they do not execute JavaScript. These page views can be seen in the special AI Assistants report.', 'wp-piwik' ),
+			$isNotTracking,
+			$fullGeneratedTrackingGroup . ' wp-piwik-track-option-manually',
+			true,
+			"window.jQuery('.wp-matomo-track-ai-warning').toggle();"
+		);
+
+		$matomoIsTrackAiEnabled            = self::$settings->isAiBotTrackingEnabled();
+		$matomoIsAdvancedCacheUsed         = self::isAdvancedCacheUsed();
+		$matomoIsTrackScriptUsedInWpConfig = self::isTrackScriptUsedInWpConfig();
+		$matomoIsHtaccessServingCacheFiles = self::isHtaccessServingCacheFiles();
+
+		if ( $matomoIsHtaccessServingCacheFiles ) {
+			?>
+			<tr>
+				<td colspan="2">
+					<div class="wp-matomo-inline-notice wp-matomo-warning wp-matomo-track-ai-warning" style="<?php echo $matomoIsTrackAiEnabled ? '' : 'display:none;'; ?>">
+						<p>
+							<strong><?php esc_html_e( 'Warning', 'wp-piwik' ); ?>:</strong>
+							<?php esc_html_e( 'Your caching plugin is using an .htaccess file to serve cached pages directly through your webserver, bypassing PHP. AI bots cannot be tracked for pages served this way. Please consult your caching plugin documentation if you wish to disable this behavior.', 'wp-piwik' ); ?>
+						</p>
+					</div>
+				</td>
+			</tr>
+			<?php
+		} elseif ( $matomoIsAdvancedCacheUsed && false === $matomoIsTrackScriptUsedInWpConfig ) {
+			?>
+			<tr>
+				<td colspan="2">
+					<div class="wp-matomo-inline-notice wp-matomo-warning wp-matomo-track-ai-warning" style="<?php echo $matomoIsTrackAiEnabled ? '' : 'display:none;'; ?>">
+						<p>
+							<strong><?php esc_html_e( 'Warning', 'wp-piwik' ); ?>:</strong>
+							<?php esc_html_e( 'We noticed WordPress\' advanced cache feature is active. This feature will serve your blog pages without ever loading your WordPress plugins. To track AI bots while the advanced cache is active you will need to add the following snippet to your wp-config.php file:', 'wp-piwik' ); ?>
+						</p>
+						<p>
+							<textarea style="width:100%" rows="3" readonly="readonly">if ( is_file( ABSPATH . 'wp-content/plugins/wp-piwik/misc/track_ai_bot.php' ) ) {
+	require_once ABSPATH . 'wp-content/plugins/wp-piwik/misc/track_ai_bot.php';
+}</textarea>
+						</p>
+						<p><?php echo sprintf( esc_html__( 'Make sure to add it immediately before the line that reads %1$srequire_once ABSPATH . \'wp-settings.php\';%2$s.', 'wp-piwik' ), '<code>', '</code>' ); ?></p>
+					</div>
+				</td>
+			</tr>
+			<?php
+		}
+
+		$this->showCheckbox(
+			\WP_Piwik\Settings::TRACK_AI_BOTS_USING_ESI,
+			esc_html__( 'Track AI Bots using Edge Side Includes', 'wp-piwik' ),
+			esc_html__( 'If you are using a CDN to serve your blog, you will not be able to track AI bots in the traditional method. If your CDN supports ESI (Edge Side Includes), however, you can enable this option to use this feature for tracking AI bots.', 'wp-piwik' ),
+			$isNotTracking,
+			$fullGeneratedTrackingGroup . ' wp-piwik-track-option-manually',
+		);
+
+		$matomoIsTrackViaEsiEnabled    = self::$settings->isTrackViaEsiEnabled();
+		$matomoIsUsingLitespeed        = $this->isUsingLitespeedWebServer();
+		$matomoIsUsingLitespeedCache   = $this->isUsingLitespeedCachePlugin();
+		$matomoIsEsiEnabledInLitespeed = $this->isLitespeedEsiEnabledInWebserver();
+
+		if ( $matomoIsUsingLitespeed && $matomoIsUsingLitespeedCache ) {
+			if ( ! $matomoIsTrackViaEsiEnabled ) {
+				?>
+			<tr>
+				<td colspan="2">
+					<div class="wp-matomo-inline-notice wp-matomo-warning wp-matomo-track-ai-warning" style="<?php echo $matomoIsTrackAiEnabled ? '' : 'display:none;'; ?>">
+						<p>
+							<strong><?php esc_html_e( 'Warning', 'matomo' ); ?>:</strong>
+							<?php esc_html_e( 'We noticed you are using a LiteSpeed webserver with the LiteSpeed Cache plugin. Tracking AI bots with LiteSpeed can only be accomplished via ESI. Please enable the feature both here and in your LiteSpeed webserver.', 'matomo' ); ?>
+						</p>
+					</div>
+				</td>
+			</tr>
+				<?php
+			} elseif ( ! $matomoIsEsiEnabledInLitespeed ) {
+				?>
+			<tr>
+				<td colspan="2">
+					<div class="wp-matomo-inline-notice wp-matomo-warning wp-matomo-track-ai-warning" style="<?php echo $matomoIsTrackAiEnabled ? '' : 'display:none;'; ?>">
+						<p>
+							<strong><?php esc_html_e( 'Warning', 'matomo' ); ?>:</strong>
+							<?php
+								echo sprintf(
+									esc_html__( 'ESI is not currently enabled in your LiteSpeed webserver. To track AI bots with LiteSpeed it is required to enable this feature. %1$sSee LiteSpeed docs for more info.%2$s', 'matomo' ),
+									'<a href="https://docs.litespeedtech.com/lscache/lscwp/cache/#esi-tab" target="_blank" rel="noreferrer noopener">',
+									'</a>'
+								);
+							?>
+						</p>
+					</div>
+				</td>
+			</tr>
+				<?php
+			}
+		}
+
 		echo $submitButton;
 		echo '</tbody></table><table id="expert" class="wp-piwik_menu-tab hidden"><tbody>';
 
@@ -813,4 +917,81 @@ class Settings extends \WP_Piwik\Admin {
 		</div>
 	<?php }
 
+
+	/**
+	 * Returns true if WordPress is configured to use the advanced-cache.php
+	 * file, and if such a file exists.
+	 *
+	 * @return bool
+	 */
+	public static function isAdvancedCacheUsed() {
+		return defined( 'WP_CACHE' )
+			&& WP_CACHE
+			&& is_file( WP_CONTENT_DIR . '/advanced-cache.php' );
+	}
+
+	/**
+	 * To track AI bots when the advanced-cache.php file is in use, a
+	 * special code snippet must be added to a user's wp-config.php.
+	 *
+	 * This function checks if the required snippet has been added to
+	 * this WordPress' wp-config.php file.
+	 *
+	 * @param string $abspathOverride only used for tests.
+	 * @return bool|null true if the snippet is detected, false if it is not,
+	 *                   and null if the wp-config.php file cannot be read for
+	 *                   some reason
+	 */
+	public static function isTrackScriptUsedInWpConfig( $abspathOverride = null ) {
+		$abspathOverride = ! empty( $abspathOverride ) ? $abspathOverride : ABSPATH;
+
+		$wpConfigPath = $abspathOverride . '/wp-config.php';
+
+		if ( ! is_readable( $wpConfigPath ) ) {
+			return null;
+		}
+
+		// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$wpConfigContents = @file_get_contents( $wpConfigPath );
+
+		// some systems may disable reading of files outside of wp-content
+		if ( ! is_string( $wpConfigContents ) ) {
+			return null;
+		}
+
+		$isTrackAiBotScriptUsed = preg_match( '/require_once.*?track_ai_bot\.php/', $wpConfigContents ) === 1;
+
+		return $isTrackAiBotScriptUsed;
+	}
+
+	public static function isHtaccessServingCacheFiles() {
+		if ( ! is_file( ABSPATH . '/.htaccess' ) ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'apache_get_modules' ) ) {
+			return false; // not using apache
+		}
+
+		$htaccessContents     = file_get_contents( ABSPATH . '/.htaccess' );
+		$isRewriteRuleFound = preg_match( '%RewriteRule.*?/wp-content/cache/%', $htaccessContents ) === 1;
+
+		return $isRewriteRuleFound;
+	}
+
+
+	public function isUsingLitespeedWebServer() {
+		return php_sapi_name() === 'litespeed';
+	}
+
+	public function isUsingLitespeedCachePlugin() {
+		return is_plugin_active( 'litespeed-cache/litespeed-cache.php' );
+	}
+
+	private function isLitespeedEsiEnabledInWebserver() {
+		// see https://docs.litespeedtech.com/lscache/lscwp/api/#get-esi-enable-status
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		return (bool) apply_filters( 'litespeed_esi_status', false );
+	}
 }

--- a/classes/WP_Piwik/AjaxTracker.php
+++ b/classes/WP_Piwik/AjaxTracker.php
@@ -25,7 +25,7 @@ class AjaxTracker extends \WP_Piwik\MatomoTracker {
 	public function __construct( Settings $settings, Logger $logger ) {
 		$this->logger = $logger;
 
-		$idsite = $settings->getOption('site_id' );
+		$idsite = $settings->getOption( 'site_id' );
 		if ( ! $idsite ) {
 			return;
 		}
@@ -111,7 +111,7 @@ class AjaxTracker extends \WP_Piwik\MatomoTracker {
 		return $response['body'];
 	}
 
-	private function isInvalidVisitorIdError(\Exception $ex ) {
+	private function isInvalidVisitorIdError( \Exception $ex ) {
 		return strpos( $ex->getMessage(), 'setVisitorId() expects' ) === 0;
 	}
 
@@ -137,7 +137,7 @@ class AjaxTracker extends \WP_Piwik\MatomoTracker {
 	}
 
 	/**
-	 * In Matomo for WordPress we want to rely entirely on JavaScript tracker
+	 * In Connect Matomo we want to rely entirely on JavaScript tracker
 	 * for creating cookies.
 	 *
 	 * @return void

--- a/classes/WP_Piwik/AjaxTracker.php
+++ b/classes/WP_Piwik/AjaxTracker.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+namespace WP_Piwik;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // if accessed directly
+}
+
+if ( ! class_exists( '\WP_Piwik\PiwikTracker' ) ) {
+	include_once __DIR__ . '/../../libs/matomo-php-tracker/MatomoTracker.php';
+}
+
+class AjaxTracker extends \WP_Piwik\MatomoTracker {
+
+	private $hasCookie = false;
+	private $logger;
+
+	public function __construct( Settings $settings, Logger $logger ) {
+		$this->logger = $logger;
+
+		$idsite = $settings->getOption('site_id' );
+		if ( ! $idsite ) {
+			return;
+		}
+
+		$apiEndpoint = rtrim( $settings->getMatomoUrl(), '/' ) . '/matomo.php';
+
+		parent::__construct( (int) $idsite, $apiEndpoint );
+
+		$this->ip = false;
+
+		if ( ! $settings->getGlobalOption( 'disable_cookies' ) ) {
+			$cookie_domain = $this->getTrackingCookieDomain($settings);
+			$this->enableCookies( $cookie_domain );
+		} else {
+			$this->disableCookieSupport();
+		}
+
+		if ( $this->loadVisitorIdCookie() ) {
+			if ( ! empty( $this->cookieVisitorId ) ) {
+				$this->hasCookie = true;
+				$this->setVisitorIdSafe( $this->cookieVisitorId );
+			}
+		}
+	}
+
+	public function setVisitorIdSafe($visitor_id ) {
+		try {
+			$this->setVisitorId( $visitor_id );
+		} catch ( \Exception $ex ) {
+			// do not fatal if the visitor ID is invalid for some reason
+			if ( ! $this->isInvalidVisitorIdError( $ex ) ) {
+				throw $ex;
+			}
+		}
+	}
+
+	protected function setCookie( $cookieName, $cookieValue, $cookieTTL ) {
+		if ( ! $this->hasCookie ) {
+			// we only set / overwrite cookies if it is a visitor that has eg no JS enabled or ad blocker enabled etc.
+			// this way we will track all cart updates and orders into the same visitor on following requests.
+			// If we recognized the visitor before via cookie we want in our case to make sure to not overwrite
+			// any cookie
+			parent::setCookie( $cookieName, $cookieValue, $cookieTTL );
+		}
+	}
+
+	protected function sendRequest( string $url, string $method = 'GET', $data = null, bool $force = false ): string {
+		if ( ! $this->idSite ) {
+			$this->logger->log('ecommerce tracking could not find idSite, cannot send request');
+			return ''; // not installed or synced yet
+		}
+
+		if ( $this->isPrerender() ) {
+			// do not track if for some reason we are prerendering
+			return '';
+		}
+
+		$args = [
+			'method'   => $method,
+			'headers'  => [
+				'User-Agent' => $this->userAgent,
+			],
+			'blocking' => false,
+		];
+		if ( ! empty( $data ) ) {
+			$args['body'] = $data;
+		}
+
+		$url = $url . '&bots=1';
+
+		try {
+			$response = $this->wpRemoteRequest( $url, $args );
+		} catch ( \Exception $ex ) {
+			$this->logger->log( 'ajax_tracker: ' . $ex->getMessage() );
+			return '';
+		}
+
+		if ( is_wp_error( $response ) ) {
+			$this->logger->log( 'ajax_tracker: ' . new \Exception( $response->get_error_message() ) );
+			return '';
+		}
+
+		return $response['body'];
+	}
+
+	private function isInvalidVisitorIdError(\Exception $ex ) {
+		return strpos( $ex->getMessage(), 'setVisitorId() expects' ) === 0;
+	}
+
+	/**
+	 * See https://developer.chrome.com/docs/web-platform/prerender-pages
+	 * @return bool
+	 */
+	private function isPrerender() {
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$purpose = strtolower( isset( $_SERVER['HTTP_SEC_PURPOSE'] ) ? wp_unslash( $_SERVER['HTTP_SEC_PURPOSE'] ) : '' );
+		return strpos( $purpose, 'prefetch' ) !== false
+			|| strpos( $purpose, 'prerender' ) !== false;
+	}
+
+	/**
+	 * for tests to override
+	 * @param string $url
+	 * @param array $args
+	 * @return array|\WP_Error
+	 */
+	protected function wpRemoteRequest($url, $args ) {
+		return wp_remote_request( $url, $args );
+	}
+
+	/**
+	 * In Matomo for WordPress we want to rely entirely on JavaScript tracker
+	 * for creating cookies.
+	 *
+	 * @return void
+	 */
+	protected function setFirstPartyCookies() {
+		// disabled
+	}
+
+	public function getTrackingCookieDomain( Settings $settings ) {
+		if (
+			$settings->getGlobalOption( 'track_across' )
+			|| $settings->getGlobalOption( 'track_crossdomain_linking' )
+		) {
+			$host = wp_parse_url( home_url(), PHP_URL_HOST );
+			if ( ! empty( $host ) ) {
+				return '*.' . $host;
+			}
+		}
+
+		return '';
+	}
+}

--- a/classes/WP_Piwik/AjaxTracker.php
+++ b/classes/WP_Piwik/AjaxTracker.php
@@ -146,6 +146,10 @@ class AjaxTracker extends \WP_Piwik\MatomoTracker {
 		// disabled
 	}
 
+	public static function getCurrentUrl(): string {
+		return parent::getCurrentUrl();
+	}
+
 	public function getTrackingCookieDomain( Settings $settings ) {
 		if (
 			$settings->getGlobalOption( 'track_across' )

--- a/classes/WP_Piwik/Logger.php
+++ b/classes/WP_Piwik/Logger.php
@@ -3,11 +3,11 @@
 	namespace WP_Piwik;
 
 	abstract class Logger {
-		
+
 		private $loggerName = 'unnamed';
 		private $loggerContent = array();
 		private $startMicrotime = null;
-		
+
 		abstract function loggerOutput($loggerTime, $loggerMessage);
 
 		public function __construct($loggerName) {
@@ -15,33 +15,44 @@
 			$this->setStartMicrotime(microtime(true));
 			$this->log('Logging started -------------------------------');
 		}
-				
+
+		public static function makeLogger() {
+			switch (WP_PIWIK_ACTIVATE_LOGGER) {
+				case 1 :
+					return new \WP_Piwik\Logger\Screen ( __CLASS__ );
+				case 2 :
+					return new \WP_Piwik\Logger\File ( __CLASS__ );
+				default :
+					return new \WP_Piwik\Logger\Dummy ( __CLASS__ );
+			}
+		}
+
 		public function __destruct() {
 			$this->log('Logging finished ------------------------------');
 		}
-		
+
 		public function log($loggerMessage) {
 			$this->loggerOutput($this->getElapsedMicrotime(), $loggerMessage);
 		}
-		
+
 		private function setName($loggerName) {
 			$this->loggerName = $loggerName;
 		}
-		
+
 		public function getName() {
 			return $this->loggerName;
 		}
-		
+
 		private function setStartMicrotime($startMicrotime) {
 			$this->startMicrotime = $startMicrotime;
 		}
-		
+
 		public function getStartMicrotime() {
 			return $this->startMicrotime;
 		}
-		
+
 		public function getElapsedMicrotime() {
 			return microtime(true) - $this->getStartMicrotime();
 		}
-		
+
 	}

--- a/classes/WP_Piwik/Request/Rest.php
+++ b/classes/WP_Piwik/Request/Rest.php
@@ -3,14 +3,10 @@
 	namespace WP_Piwik\Request;
 
 	class Rest extends \WP_Piwik\Request {
-			
+
 		protected function request($id) {
 			$count = 0;
-			if (self::$settings->getGlobalOption('piwik_mode') == 'http')
-				$url = self::$settings->getGlobalOption('piwik_url');
-			else if (self::$settings->getGlobalOption('piwik_mode') == 'cloud')
-				$url = 'https://'.self::$settings->getGlobalOption('piwik_user').'.innocraft.cloud/';
-			else $url = 'https://'.self::$settings->getGlobalOption('matomo_user').'.matomo.cloud/';
+			$url = self::$settings->getMatomoUrl();
 			$params = 'module=API&method=API.getBulkRequest&format=json';
 			if (self::$settings->getGlobalOption('filter_limit') != "" && self::$settings->getGlobalOption('filter_limit') == (int) self::$settings->getGlobalOption('filter_limit'))
                 $params .= '&filter_limit='.self::$settings->getGlobalOption('filter_limit');
@@ -27,7 +23,7 @@
 				    if (isset($map[$num]))
 					    self::$results[$map[$num]] = $result;
 		}
-			
+
 		private function curl($id, $url, $params) {
 			if (self::$settings->getGlobalOption('http_method')=='post') {
 				$c = curl_init($url);

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -10,22 +10,27 @@ namespace WP_Piwik;
  */
 class Settings {
 
+	const TRACK_AI_BOTS           = 'track_ai_bots';
+	const TRACK_AI_BOTS_USING_ESI = 'track_ai_bots_using_esi';
+
 	/**
 	 *
 	 * @var Environment variables and default settings container
 	 */
-	private static $wpPiwik, $defaultSettings;
+	private static $wpPiwik;
+
+	private static $defaultSettings;
 
 	/**
 	 *
 	 * @var Define callback functions for changed settings
 	 */
 	private $checkSettings = array (
-			'piwik_url' => 'checkPiwikUrl',
-			'piwik_token' => 'checkPiwikToken',
-			'site_id' => 'requestPiwikSiteID',
-			'tracking_code' => 'prepareTrackingCode',
-			'noscript_code' => 'prepareNocscriptCode'
+		'piwik_url' => 'checkPiwikUrl',
+		'piwik_token' => 'checkPiwikToken',
+		'site_id' => 'requestPiwikSiteID',
+		'tracking_code' => 'prepareTrackingCode',
+		'noscript_code' => 'prepareNocscriptCode'
 	);
 
 	/**
@@ -33,95 +38,102 @@ class Settings {
 	 * @var Register default configuration set
 	 */
 	private $globalSettings = array (
-			// Plugin settings
-			'revision' => 0,
-			'last_settings_update' => 0,
-			// User settings: Piwik configuration
-			'piwik_mode' => 'http',
-			'piwik_url' => '',
-			'piwik_path' => '',
-			'piwik_user' => '',
-			'matomo_user' => '',
-			'piwik_token' => '',
-			'auto_site_config' => true,
-			// User settings: Stats configuration
-			'default_date' => 'yesterday',
-			'stats_seo' => false,
-            'stats_ecommerce' => false,
-			'dashboard_widget' => false,
-			'dashboard_ecommerce' => false,
-			'dashboard_chart' => false,
-			'dashboard_seo' => false,
-			'toolbar' => false,
-			'capability_read_stats' => array (
-					'administrator' => true
-			),
-			'perpost_stats' => "disabled",
-			'plugin_display_name' => 'Connect Matomo',
-			'piwik_shortcut' => false,
-			'shortcodes' => false,
-			// User settings: Tracking configuration
-			'track_mode' => 'disabled',
-			'track_codeposition' => 'footer',
-			'track_noscript' => false,
-			'track_nojavascript' => false,
-			'proxy_url' => '',
-			'track_content' => 'disabled',
-			'track_search' => false,
-			'track_404' => false,
-			'add_post_annotations' => array(),
-			'add_customvars_box' => false,
-			'add_download_extensions' => '',
-			'set_download_extensions' => '',
-			'set_link_classes' => '',
-			'set_download_classes' => '',
-            'require_consent' => 'disabled',
-			'disable_cookies' => false,
-			'limit_cookies' => false,
-			'limit_cookies_visitor' => 34186669, // Piwik default 13 months
-			'limit_cookies_session' => 1800, // Piwik default 30 minutes
-			'limit_cookies_referral' => 15778463, // Piwik default 6 months
-			'track_admin' => false,
-			'capability_stealth' => array (),
-			'track_across' => false,
-			'track_across_alias' => false,
-			'track_crossdomain_linking' => false,
-			'track_feed' => false,
-			'track_feed_addcampaign' => false,
-			'track_feed_campaign' => 'feed',
-			'track_heartbeat' => 0,
-			'track_user_id' => 'disabled',
-			// User settings: Expert configuration
-			'cache' => true,
-			'http_connection' => 'curl',
-			'http_method' => 'post',
-			'disable_timelimit' => false,
-			'filter_limit' => '',
-			'connection_timeout' => 5,
-			'disable_ssl_verify' => false,
-			'disable_ssl_verify_host' => false,
-			'piwik_useragent' => 'php',
-			'piwik_useragent_string' => 'WP-Piwik',
-            'dnsprefetch' => false,
-			'track_datacfasync' => false,
-			'track_cdnurl' => '',
-			'track_cdnurlssl' => '',
-			'force_protocol' => 'disabled',
-			'remove_type_attribute' => false,
-			'update_notice' => 'enabled'
-	), $settings = array (
-			'name' => '',
-			'site_id' => NULL,
-			'noscript_code' => '',
-			'tracking_code' => '',
-			'last_tracking_code_update' => 0,
-			'dashboard_revision' => 0
-	), $settingsChanged = false;
+		// Plugin settings
+		'revision' => 0,
+		'last_settings_update' => 0,
+		// User settings: Piwik configuration
+		'piwik_mode' => 'http',
+		'piwik_url' => '',
+		'piwik_path' => '',
+		'piwik_user' => '',
+		'matomo_user' => '',
+		'piwik_token' => '',
+		'auto_site_config' => true,
+		// User settings: Stats configuration
+		'default_date' => 'yesterday',
+		'stats_seo' => false,
+		'stats_ecommerce' => false,
+		'dashboard_widget' => false,
+		'dashboard_ecommerce' => false,
+		'dashboard_chart' => false,
+		'dashboard_seo' => false,
+		'toolbar' => false,
+		'capability_read_stats' => array (
+				'administrator' => true
+		),
+		'perpost_stats' => "disabled",
+		'plugin_display_name' => 'Connect Matomo',
+		'piwik_shortcut' => false,
+		'shortcodes' => false,
+		// User settings: Tracking configuration
+		'track_mode' => 'disabled',
+		'track_codeposition' => 'footer',
+		'track_noscript' => false,
+		'track_nojavascript' => false,
+		'proxy_url' => '',
+		'track_content' => 'disabled',
+		'track_search' => false,
+		'track_404' => false,
+		'add_post_annotations' => array(),
+		'add_customvars_box' => false,
+		'add_download_extensions' => '',
+		'set_download_extensions' => '',
+		'set_link_classes' => '',
+		'set_download_classes' => '',
+		'require_consent' => 'disabled',
+		'disable_cookies' => false,
+		'limit_cookies' => false,
+		'limit_cookies_visitor' => 34186669, // Piwik default 13 months
+		'limit_cookies_session' => 1800, // Piwik default 30 minutes
+		'limit_cookies_referral' => 15778463, // Piwik default 6 months
+		'track_admin' => false,
+		'capability_stealth' => array (),
+		'track_across' => false,
+		'track_across_alias' => false,
+		'track_crossdomain_linking' => false,
+		'track_feed' => false,
+		'track_feed_addcampaign' => false,
+		'track_feed_campaign' => 'feed',
+		'track_heartbeat' => 0,
+		'track_user_id' => 'disabled',
+		// User settings: Expert configuration
+		'cache' => true,
+		'http_connection' => 'curl',
+		'http_method' => 'post',
+		'disable_timelimit' => false,
+		'filter_limit' => '',
+		'connection_timeout' => 5,
+		'disable_ssl_verify' => false,
+		'disable_ssl_verify_host' => false,
+		'piwik_useragent' => 'php',
+		'piwik_useragent_string' => 'WP-Piwik',
+		'dnsprefetch' => false,
+		'track_datacfasync' => false,
+		'track_cdnurl' => '',
+		'track_cdnurlssl' => '',
+		'force_protocol' => 'disabled',
+		'remove_type_attribute' => false,
+		'update_notice' => 'enabled',
+
+		self::TRACK_AI_BOTS => false,
+		self::TRACK_AI_BOTS_USING_ESI => false,
+	);
+
+	private $settings = array (
+		'name' => '',
+		'site_id' => NULL,
+		'noscript_code' => '',
+		'tracking_code' => '',
+		'last_tracking_code_update' => 0,
+		'dashboard_revision' => 0
+	);
+
+	private $settingsChanged = false;
 
 	/**
 	 * Constructor class to prepare settings manager
 	 *
-	 * @param WP_Piwik $wpPiwik
+	 * @param \WP_Piwik $wpPiwik
 	 *        	active WP-Piwik instance
 	 */
 	public function __construct($wpPiwik) {
@@ -207,7 +219,7 @@ class Settings {
 	 *        	option key
 	 * @param int $blogID
 	 *        	blog ID (default: current blog)
-	 * @return \WP_Piwik\Register
+	 * @return mixed
 	 */
 	public function getOption($key, $blogID = null) {
 		if ($this->checkNetworkActivation () && ! empty ( $blogID )) {
@@ -423,5 +435,33 @@ class Settings {
 		);
 		$debug['global_settings']['piwik_token'] = !empty($debug['global_settings']['piwik_token'])?'set':'not set';
 		return $debug;
+	}
+
+	public function isAiBotTrackingEnabled() {
+		return (bool) $this->getGlobalOption( self::TRACK_AI_BOTS );
+	}
+
+	public function isAiBotTrackingEnabledViaEsiIncludes() {
+		return (bool) $this->getGlobalOption( self::TRACK_AI_BOTS_USING_ESI );
+	}
+
+	public function isTrackViaEsiEnabled() {
+		return ( (bool) $this->getGlobalOption( 'track_ai_bots_using_esi' ) ) === true;
+	}
+
+	public function getMatomoUrl() {
+		if ($this->getGlobalOption('piwik_mode') == 'http') {
+			return $this->getGlobalOption('piwik_url');
+		}
+
+		if ($this->getGlobalOption('piwik_mode') == 'cloud') {
+			return 'https://' . $this->getGlobalOption('piwik_user') . '.innocraft.cloud/';
+		}
+
+		return 'https://'.$this->getGlobalOption('matomo_user').'.matomo.cloud/';
+	}
+
+	public function isTrackingEnabled() {
+		return $this->getGlobalOption('track_mode') !== 'disabled';
 	}
 }

--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -30,6 +30,12 @@ class TrackingCode {
 		return $this->trackingCode;
 	}
 
+	/**
+	 * @param string $code
+	 * @param Settings $settings
+	 * @param Logger $logger
+	 * @return array
+	 */
 	public static function prepareTrackingCode($code, $settings, $logger) {
 		global $current_user;
 		$logger->log ( 'Apply tracking code changes:' );
@@ -74,6 +80,52 @@ class TrackingCode {
 
 		if ($settings->getGlobalOption ( 'track_datacfasync' ))
 			$code = str_replace ( '<script type', '<script data-cfasync="false" type', $code );
+
+		if ( $settings->isAiBotTrackingEnabled() ) {
+			// recMode is a temporary parameter introduced in core to conditionally
+			// enable AI bot tracking. if AI bot tracking is enabled in MWP, we set
+			// it to `2` here, to enable "auto" mode when doing JS tracking. in this
+			// mode, tracking requests with AI bot user agents will be tracked as bots
+			// instead of visits, while all other requests will be tracked normally
+			// as visits.
+			$code = str_replace(
+				"_paq.push(['trackPageView']);",
+				"_paq.push(['appendToTrackingUrl', 'recMode=2']);\n_paq.push(['trackPageView']);",
+				$code
+			);
+
+			// set cookie via javascript cookie for known AI bots so we can skip tracking server side
+			// for them.
+			// NOTE: this must be done ONLY for known AI bots to be compliant with privacy regulations.
+			$user_agent_substrings = wp_json_encode( AjaxTracker::AI_BOT_USER_AGENT_SUBSTRINGS );
+
+			$cookie_set_fn = <<<EOF
+_paq.push([ function () {
+  var userAgentSubstrings = $user_agent_substrings;
+  for (var i = 0; i < userAgentSubstrings.length; ++i) {
+  	var isAiBotUserAgent = navigator.userAgent.toLowerCase().indexOf(userAgentSubstrings[i].toLowerCase()) !== -1;
+  	if (isAiBotUserAgent) {
+      var path = this.getCookiePath();
+      var domain = this.getCookieDomain();
+      var sameSite = 'Lax';
+      document.cookie = 'matomo_has_js=1;path=' +
+      	(path || '/') +
+      	(domain ? ';domain=' + domain : '') +
+		';SameSite=' + sameSite
+		;
+  	  return;
+  	}
+  }
+} ]);
+EOF;
+
+			$code = str_replace(
+				"_paq.push(['trackPageView']);",
+				$cookie_set_fn . "\n_paq.push(['trackPageView']);",
+				$code
+			);
+		}
+
 		if ($settings->getGlobalOption ( 'set_download_extensions' ))
 			$code = str_replace ( "_paq.push(['trackPageView']);", "_paq.push(['setDownloadExtensions', '" . ($settings->getGlobalOption ( 'set_download_extensions' )) . "']);\n_paq.push(['trackPageView']);", $code );
 		if ($settings->getGlobalOption ( 'add_download_extensions' ))
@@ -151,7 +203,7 @@ class TrackingCode {
          	if ( isset( $pkUserId ) && ! empty( $pkUserId ))
 			$this->trackingCode = str_replace ( "_paq.push(['trackPageView']);", "_paq.push(['setUserId', '" . esc_js( $pkUserId ) . "']);\n_paq.push(['trackPageView']);", $this->trackingCode );
 	}
-	
+
 	private function addCustomValues() {
 		$customVars = '';
 		for($i = 1; $i <= 5; $i ++) {

--- a/classes/WP_Piwik/TrackingCode.php
+++ b/classes/WP_Piwik/TrackingCode.php
@@ -83,10 +83,10 @@ class TrackingCode {
 
 		if ( $settings->isAiBotTrackingEnabled() ) {
 			// recMode is a temporary parameter introduced in core to conditionally
-			// enable AI bot tracking. if AI bot tracking is enabled in MWP, we set
-			// it to `2` here, to enable "auto" mode when doing JS tracking. in this
-			// mode, tracking requests with AI bot user agents will be tracked as bots
-			// instead of visits, while all other requests will be tracked normally
+			// enable AI bot tracking. if AI bot tracking is enabled in Connect Matomo,
+			// we set it to `2` here, to enable "auto" mode when doing JS tracking. in
+			// this mode, tracking requests with AI bot user agents will be tracked as
+			// bots instead of visits, while all other requests will be tracked normally
 			// as visits.
 			$code = str_replace(
 				"_paq.push(['trackPageView']);",

--- a/css/wp-piwik.css
+++ b/css/wp-piwik.css
@@ -72,3 +72,11 @@ div.wp-piwik-donate div {
 	border-width:1px 0 0 0 ;
 	padding:5px
 }
+
+.wp-matomo-inline-notice {
+    padding: 1em;
+}
+
+.wp-matomo-inline-notice.wp-matomo-warning {
+    background-color: rgba(255, 165, 0, 0.2);
+}

--- a/libs/matomo-php-tracker/.gitattributes
+++ b/libs/matomo-php-tracker/.gitattributes
@@ -1,0 +1,2 @@
+tests/ export-ignore
+run_tests.sh export-ignore

--- a/libs/matomo-php-tracker/.gitignore
+++ b/libs/matomo-php-tracker/.gitignore
@@ -1,0 +1,5 @@
+/.idea/
+/vendor/
+.phpunit.result.cache
+/tests/.phpunit.result.cache
+composer.lock

--- a/libs/matomo-php-tracker/CHANGELOG.md
+++ b/libs/matomo-php-tracker/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Matomo PHP Tracker Changelog
+
+This is the Developer Changelog for Matomo PHP Tracker. All breaking changes or new features are listed below.
+
+## Matomo PHP Tracker 3.3.2
+### Changed
+- Support for formFactors client hint parameter, supported as of Matomo 5.2.0
+
+## Matomo PHP Tracker 3.3.1
+### Fixed
+- closed curl connection
+
+## Matomo PHP Tracker 3.3.0
+### Removed
+- support for PHP versions lower than 7.2
+### Changed
+- all `MatomoTracker` class constants are now explicitly public
+- all `MatomoTracker` dynamic properties are now explicitly public
+
+## Matomo PHP Tracker 3.0.0
+
+Attention: This version of Matomo PHP Tracker is no longer compatible with Matomo 3.x or earlier
+
+- Support for new page performance metrics (added in Matomo 4) has been added. You can use `setPerformanceTimings()` to set them for page views.
+- Setting page generation time using `setGenerationTime()` has been discontinued. The method still exists to not break applications still using it, but it does not have any effect. Please use new page performance metrics as replacement.
+- Sending requests using cURL will now throw an exception if an error occurs in a request.
+- Matomo does not longer support tracking of these browser plugins: Gears, Director. Therefor the signature of `setPlugins()` changed.
+- Implementation of ecommerce views changed from custom variables to raw parameters
+- It is now possible to configure cookie options for Secure, HTTPOnly and SameSite.
+- Add method setRequestMethodNonBulk() to allow (non bulk) POST requests.

--- a/libs/matomo-php-tracker/LICENSE
+++ b/libs/matomo-php-tracker/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014, Matomo Open Source Analytics
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/libs/matomo-php-tracker/MatomoTracker.php
+++ b/libs/matomo-php-tracker/MatomoTracker.php
@@ -1,0 +1,2664 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * For more information, see README.md
+ *
+ * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
+ * @link https://matomo.org/docs/tracking-api/
+ *
+ * @category Matomo
+ * @package MatomoTracker
+ */
+
+namespace WP_Piwik;
+
+/**
+ * MatomoTracker implements the Matomo Tracking Web API.
+ *
+ * For more information, see: https://github.com/matomo-org/matomo-php-tracker/
+ *
+ * @package MatomoTracker
+ * @api
+ */
+#[AllowDynamicProperties]
+class MatomoTracker
+{
+	/**
+	 * Matomo base URL, for example http://example.org/matomo/
+	 * Must be set before using the class by calling
+	 * MatomoTracker::$URL = 'http://yourwebsite.org/matomo/';
+	 *
+	 * @var string
+	 */
+	static public $URL = '';
+
+	public const AI_BOT_USER_AGENT_SUBSTRINGS = [
+		'GPTBot',
+		'ChatGPT-User',
+		'MistralAI-User',
+		'Gemini-Deep-Research',
+		'Claude-User',
+		'Perplexity-User',
+		'GoogleAgent',
+		'Devin',
+		'NovaAct',
+		'Google-Extended',
+		'Google-CloudVertexBot',
+	];
+
+	/**
+	 * API Version
+	 *
+	 * @ignore
+	 * @var int
+	 */
+	public const VERSION = 1;
+
+	/**
+	 * @ignore
+	 */
+	public $DEBUG_APPEND_URL = '';
+
+	/**
+	 * Visitor ID length
+	 *
+	 * @ignore
+	 */
+	public const LENGTH_VISITOR_ID = 16;
+
+	/**
+	 * Charset
+	 * @see setPageCharset
+	 * @ignore
+	 */
+	public const DEFAULT_CHARSET_PARAMETER_VALUES = 'utf-8';
+
+	/**
+	 * See matomo.js
+	 */
+	public const FIRST_PARTY_COOKIES_PREFIX = '_pk_';
+
+	/**
+	 * Defines how many categories can be used max when calling addEcommerceItem().
+	 * @var int
+	 */
+	public const MAX_NUM_ECOMMERCE_ITEM_CATEGORIES = 5;
+
+	public const DEFAULT_COOKIE_PATH = '/';
+
+	public $ecommerceItems = [];
+
+	public $attributionInfo = false;
+
+	public $eventCustomVar = [];
+
+	public $forcedDatetime = false;
+
+	public $forcedNewVisit = false;
+
+	public $networkTime = false;
+
+	public $serverTime = false;
+
+	public $transferTime = false;
+
+	public $domProcessingTime = false;
+
+	public $domCompletionTime = false;
+
+	public $onLoadTime = false;
+
+	public $pageCustomVar = [];
+
+	public $ecommerceView = [];
+
+	public $customParameters = [];
+
+	public $customDimensions = [];
+
+	public $customData = false;
+
+	public $hasCookies = false;
+
+	public $token_auth = false;
+
+	public $userAgent = false;
+
+	public $country = false;
+
+	public $region = false;
+
+	public $city = false;
+
+	public $lat = false;
+
+	public $long = false;
+
+	public $width = false;
+
+	public $height = false;
+
+	public $plugins = false;
+
+	public $localHour = false;
+
+	public $localMinute = false;
+
+	public $localSecond = false;
+
+	public $idPageview = false;
+
+	public $idPageviewSetManually = false;
+
+	public $idSite;
+
+	public $urlReferrer;
+
+	public $pageCharset = self::DEFAULT_CHARSET_PARAMETER_VALUES;
+
+	public $pageUrl;
+
+	public $ip;
+
+	public $acceptLanguage;
+
+	public $clientHints = [];
+
+	// Life of the visitor cookie (in sec)
+	public $configVisitorCookieTimeout = 33955200; // 13 months (365 + 28 days)
+
+	// Life of the session cookie (in sec)
+	public $configSessionCookieTimeout = 1800; // 30 minutes
+
+	// Life of the session cookie (in sec)
+	public $configReferralCookieTimeout = 15768000; // 6 months
+
+	// Visitor Ids in order
+	public $userId = false;
+
+	public $forcedVisitorId = false;
+
+	public $cookieVisitorId = false;
+
+	public $randomVisitorId = false;
+
+	public $configCookiesDisabled = false;
+
+	public $configCookiePath = self::DEFAULT_COOKIE_PATH;
+
+	public $configCookieDomain = '';
+
+	public $configCookieSameSite = '';
+
+	public $configCookieSecure = false;
+
+	public $configCookieHTTPOnly = false;
+
+	public $currentTs;
+
+	public $createTs;
+
+	// Allow debug while blocking the request
+	public $requestTimeout = 600;
+
+	public $requestConnectTimeout = 300;
+
+	public $doBulkRequests = false;
+
+	public $storedTrackingActions = [];
+
+	public $sendImageResponse = true;
+
+	public $outgoingTrackerCookies = [];
+
+	public $incomingTrackerCookies = [];
+
+	public $visitorCustomVar;
+
+	private $requestMethod = null;
+
+	/**
+	 * Builds a MatomoTracker object, used to track visits, pages and Goal conversions
+	 * for a specific website, by using the Matomo Tracking API.
+	 *
+	 * @param int $idSite Id site to be tracked
+	 * @param string $apiUrl "http://example.org/matomo/" or "http://matomo.example.org/"
+	 *                         If set, will overwrite MatomoTracker::$URL
+	 */
+	public function __construct(int $idSite, string $apiUrl = '')
+	{
+		$this->idSite = $idSite;
+		$this->urlReferrer = !empty($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : false;
+		$this->pageUrl = self::getCurrentUrl();
+		$this->ip = !empty($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : false;
+		$this->acceptLanguage = !empty($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : false;
+		$this->userAgent = !empty($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : false;
+		$this->setClientHints(
+			!empty($_SERVER['HTTP_SEC_CH_UA_MODEL']) ? $_SERVER['HTTP_SEC_CH_UA_MODEL'] : '',
+			!empty($_SERVER['HTTP_SEC_CH_UA_PLATFORM']) ? $_SERVER['HTTP_SEC_CH_UA_PLATFORM'] : '',
+			!empty($_SERVER['HTTP_SEC_CH_UA_PLATFORM_VERSION']) ? $_SERVER['HTTP_SEC_CH_UA_PLATFORM_VERSION'] : '',
+			!empty($_SERVER['HTTP_SEC_CH_UA_FULL_VERSION_LIST']) ? $_SERVER['HTTP_SEC_CH_UA_FULL_VERSION_LIST'] : '',
+			!empty($_SERVER['HTTP_SEC_CH_UA_FULL_VERSION']) ? $_SERVER['HTTP_SEC_CH_UA_FULL_VERSION'] : ''
+		);
+		if (!empty($apiUrl)) {
+			self::$URL = $apiUrl;
+		}
+
+		$this->setNewVisitorId();
+
+		$this->currentTs = time();
+		$this->createTs = $this->currentTs;
+
+		$this->visitorCustomVar = $this->getCustomVariablesFromCookie();
+	}
+
+	public function setApiUrl(string $url): void
+	{
+		self::$URL = $url;
+	}
+
+	/**
+	 * By default, Matomo expects utf-8 encoded values, for example
+	 * for the page URL parameter values, Page Title, etc.
+	 * It is recommended to only send UTF-8 data to Matomo.
+	 * If required though, you can also specify another charset using this function.
+	 *
+	 * @return $this
+	 */
+	public function setPageCharset(string $charset = '')
+	{
+		$this->pageCharset = $charset;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the current URL being tracked
+	 *
+	 * @param string $url Raw URL (not URL encoded)
+	 * @return $this
+	 */
+	public function setUrl(string $url)
+	{
+		$this->pageUrl = $url;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the URL referrer used to track Referrers details for new visits.
+	 *
+	 * @param string $url Raw URL (not URL encoded)
+	 * @return $this
+	 */
+	public function setUrlReferrer(string $url)
+	{
+		$this->urlReferrer = $url;
+
+		return $this;
+	}
+
+	/**
+	 * This method is deprecated and does nothing. It used to set the time that it took to generate the document on the server side.
+	 *
+	 * @param int $timeMs Generation time in ms
+	 * @return $this
+	 *
+	 * @deprecated this metric is deprecated please use performance timings instead
+	 * @see setPerformanceTimings
+	 */
+	public function setGenerationTime(int $timeMs)
+	{
+		return $this;
+	}
+
+	/**
+	 * Sets timings for various browser performance metrics.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming
+	 *
+	 * @param null|int $network Network time in ms (connectEnd – fetchStart)
+	 * @param null|int $server Server time in ms (responseStart – requestStart)
+	 * @param null|int $transfer Transfer time in ms (responseEnd – responseStart)
+	 * @param null|int $domProcessing DOM Processing to Interactive time in ms (domInteractive – domLoading)
+	 * @param null|int $domCompletion DOM Interactive to Complete time in ms (domComplete – domInteractive)
+	 * @param null|int $onload Onload time in ms (loadEventEnd – loadEventStart)
+	 * @return $this
+	 */
+	public function setPerformanceTimings(
+		?int $network = null,
+		?int $server = null,
+		?int $transfer = null,
+		?int $domProcessing = null,
+		?int $domCompletion = null,
+		?int $onload = null
+	) {
+		$this->networkTime = $network;
+		$this->serverTime = $server;
+		$this->transferTime = $transfer;
+		$this->domProcessingTime = $domProcessing;
+		$this->domCompletionTime = $domCompletion;
+		$this->onLoadTime = $onload;
+
+		return $this;
+	}
+
+	/**
+	 * Clear / reset all previously set performance metrics.
+	 */
+	public function clearPerformanceTimings(): void
+	{
+		$this->networkTime = false;
+		$this->serverTime = false;
+		$this->transferTime = false;
+		$this->domProcessingTime = false;
+		$this->domCompletionTime = false;
+		$this->onLoadTime = false;
+	}
+
+	/**
+	 * @deprecated
+	 * @ignore
+	 */
+	public function setUrlReferer(string $url)
+	{
+		$this->setUrlReferrer($url);
+
+		return $this;
+	}
+
+	/**
+	 * Sets the attribution information to the visit, so that subsequent Goal conversions are
+	 * properly attributed to the right Referrer URL, timestamp, Campaign Name & Keyword.
+	 *
+	 * This must be a JSON encoded string that would typically be fetched from the JS API:
+	 * matomoTracker.getAttributionInfo() and that you have JSON encoded via JSON2.stringify()
+	 *
+	 * If you call enableCookies() then these referral attribution values will be set
+	 * to the 'ref' first party cookie storing referral information.
+	 *
+	 * @param string $jsonEncoded JSON encoded array containing Attribution info
+	 * @return $this
+	 * @throws Exception
+	 * @see function getAttributionInfo() in https://github.com/matomo-org/matomo/blob/master/js/matomo.js
+	 */
+	public function setAttributionInfo(string $jsonEncoded)
+	{
+		$decoded = json_decode($jsonEncoded, $assoc = true);
+		if (!is_array($decoded)) {
+			throw new Exception("setAttributionInfo() is expecting a JSON encoded string, $jsonEncoded given");
+		}
+		$this->attributionInfo = $decoded;
+
+		return $this;
+	}
+
+	/**
+	 * Sets Visit Custom Variable.
+	 * See https://matomo.org/docs/custom-variables/
+	 *
+	 * @param int $id Custom variable slot ID from 1-5
+	 * @param string $name Custom variable name
+	 * @param string $value Custom variable value
+	 * @param string $scope Custom variable scope. Possible values: visit, page, event
+	 * @return $this
+	 * @throws Exception
+	 */
+	public function setCustomVariable(
+		int $id,
+		string $name,
+		string $value,
+		string $scope = 'visit'
+	) {
+		if ($scope === 'page') {
+			$this->pageCustomVar[$id] = array($name, $value);
+		} elseif ($scope === 'event') {
+			$this->eventCustomVar[$id] = array($name, $value);
+		} elseif ($scope === 'visit') {
+			$this->visitorCustomVar[$id] = array($name, $value);
+		} else {
+			throw new Exception("Invalid 'scope' parameter value");
+		}
+		return $this;
+	}
+
+	/**
+	 * Returns the currently assigned Custom Variable.
+	 *
+	 * If scope is 'visit', it will attempt to read the value set in the first party cookie created by Matomo Tracker
+	 *  ($_COOKIE array).
+	 *
+	 * @param int $id Custom Variable integer index to fetch from cookie. Should be a value from 1 to 5
+	 * @param string $scope Custom variable scope. Possible values: visit, page, event
+	 *
+	 * @throws Exception
+	 * @return mixed An array with this format: array( 0 => CustomVariableName, 1 => CustomVariableValue ) or false
+	 * @see matomo.js getCustomVariable()
+	 */
+	public function getCustomVariable(int $id, string $scope = 'visit')
+	{
+		if ($scope === 'page') {
+			return $this->pageCustomVar[$id] ?? false;
+		}
+
+		if ($scope === 'event') {
+			return $this->eventCustomVar[$id] ?? false;
+		}
+
+		if ($scope !== 'visit') {
+			throw new Exception("Invalid 'scope' parameter value");
+		}
+
+		if (!empty($this->visitorCustomVar[$id])) {
+			return $this->visitorCustomVar[$id];
+		}
+		$cookieDecoded = $this->getCustomVariablesFromCookie();
+
+		if (!is_array($cookieDecoded)
+			|| !isset($cookieDecoded[$id])
+			|| !is_array($cookieDecoded[$id])
+			|| count($cookieDecoded[$id]) !== 2
+		) {
+			return false;
+		}
+
+		return $cookieDecoded[$id];
+	}
+
+	/**
+	 * Clears any Custom Variable that may be have been set.
+	 *
+	 * This can be useful when you have enabled bulk requests,
+	 * and you wish to clear Custom Variables of 'visit' scope.
+	 */
+	public function clearCustomVariables(): void
+	{
+		$this->visitorCustomVar = [];
+		$this->pageCustomVar = [];
+		$this->eventCustomVar = [];
+	}
+
+	/**
+	 * Sets a specific custom dimension
+	 *
+	 * @param int $id id of custom dimension
+	 * @param string $value value for custom dimension
+	 * @return $this
+	 */
+	public function setCustomDimension(int $id, string $value)
+	{
+		$this->customDimensions['dimension'.$id] = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Clears all previously set custom dimensions
+	 */
+	public function clearCustomDimensions(): void
+	{
+		$this->customDimensions = [];
+	}
+
+	/**
+	 * Returns the value of the custom dimension with the given id
+	 *
+	 * @param int $id id of custom dimension
+	 * @return string|null
+	 */
+	public function getCustomDimension(int $id): ?string
+	{
+		return $this->customDimensions['dimension'.$id] ?? null;
+	}
+
+	/**
+	 * Sets a custom tracking parameter. This is useful if you need to send any tracking parameters for a 3rd party
+	 * plugin that is not shipped with Matomo itself. Please note that custom parameters are cleared after each
+	 * tracking request.
+	 *
+	 * @param string $trackingApiParameter The name of the tracking API parameter, eg 'bw_bytes'
+	 * @param string $value Tracking parameter value that shall be sent for this tracking parameter.
+	 * @return $this
+	 * @throws Exception
+	 */
+	public function setCustomTrackingParameter(string $trackingApiParameter, string $value)
+	{
+		$matches = [];
+
+		if (preg_match('/^dimension([0-9]+)$/', $trackingApiParameter, $matches)) {
+			$this->setCustomDimension($matches[1], $value);
+
+			return $this;
+		}
+
+		$this->customParameters[$trackingApiParameter] = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Clear / reset all previously set custom tracking parameters.
+	 */
+	public function clearCustomTrackingParameters(): void
+	{
+		$this->customParameters = [];
+	}
+
+	/**
+	 * Sets the current visitor ID to a random new one.
+	 * @return $this
+	 */
+	public function setNewVisitorId()
+	{
+		$this->randomVisitorId = substr(md5(uniqid(rand(), true)), 0, self::LENGTH_VISITOR_ID);
+		$this->forcedVisitorId = false;
+		$this->cookieVisitorId = false;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the current site ID.
+	 *
+	 * @return $this
+	 */
+	public function setIdSite(int $idSite)
+	{
+		$this->idSite = $idSite;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the Browser language. Used to guess visitor countries when GeoIP is not enabled
+	 *
+	 * @param string $acceptLanguage For example "fr-fr"
+	 * @return $this
+	 */
+	public function setBrowserLanguage(string $acceptLanguage)
+	{
+		$this->acceptLanguage = $acceptLanguage;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the user agent, used to detect OS and browser.
+	 * If this function is not called, the User Agent will default to the current user agent.
+	 *
+	 * @param string $userAgent
+	 * @return $this
+	 */
+	public function setUserAgent(string $userAgent)
+	{
+		$this->userAgent = $userAgent;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the client hints, used to detect OS and browser.
+	 * If this function is not called, the client hints sent with the current request will be used.
+	 *
+	 * Supported as of Matomo 4.12.0
+	 *
+	 * @param string $model  Value of the header 'HTTP_SEC_CH_UA_MODEL'
+	 * @param string $platform  Value of the header 'HTTP_SEC_CH_UA_PLATFORM'
+	 * @param string $platformVersion  Value of the header 'HTTP_SEC_CH_UA_PLATFORM_VERSION'
+	 * @param string|array<string, mixed> $fullVersionList Value of header 'HTTP_SEC_CH_UA_FULL_VERSION_LIST'
+	 *      or an array containing all brands with the structure
+	 *      [['brand' => 'Chrome', 'version' => '10.0.2'], ['brand' => '...]
+	 * @param string $uaFullVersion  Value of the header 'HTTP_SEC_CH_UA_FULL_VERSION'
+	 *
+	 * @return $this
+	 */
+	public function setClientHints(
+		string $model = '',
+		string $platform = '',
+		string $platformVersion = '',
+			   $fullVersionList = '',
+		string $uaFullVersion = ''
+	) {
+		if (is_string($fullVersionList)) {
+			$reg  = '/^"([^"]+)"; ?v="([^"]+)"(?:, )?/';
+			$list = [];
+
+			while (\preg_match($reg, $fullVersionList, $matches)) {
+				$list[] = ['brand' => $matches[1], 'version' => $matches[2]];
+				$fullVersionList  = \substr($fullVersionList, \strlen($matches[0]));
+			}
+
+			$fullVersionList = $list;
+		} elseif (!is_array($fullVersionList)) {
+			$fullVersionList = [];
+		}
+
+		$this->clientHints = array_filter([
+			'model' => $model,
+			'platform' => $platform,
+			'platformVersion' => $platformVersion,
+			'uaFullVersion' => $uaFullVersion,
+			'fullVersionList' => $fullVersionList,
+		]);
+
+		return $this;
+	}
+
+	/**
+	 * Sets the country of the visitor. If not used, Matomo will try to find the country
+	 * using either the visitor's IP address or language.
+	 *
+	 * Allowed only for Admin/Super User, must be used along with setTokenAuth().
+	 *
+	 * @return $this
+	 */
+	public function setCountry(string $country)
+	{
+		$this->country = $country;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the region of the visitor. If not used, Matomo may try to find the region
+	 * using the visitor's IP address (if configured to do so).
+	 *
+	 * Allowed only for Admin/Super User, must be used along with setTokenAuth().
+	 *
+	 * @return $this
+	 */
+	public function setRegion(string $region)
+	{
+		$this->region = $region;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the city of the visitor. If not used, Matomo may try to find the city
+	 * using the visitor's IP address (if configured to do so).
+	 *
+	 * Allowed only for Admin/Super User, must be used along with setTokenAuth().
+	 *
+	 * @return $this
+	 */
+	public function setCity(string $city)
+	{
+		$this->city = $city;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the latitude of the visitor. If not used, Matomo may try to find the visitor's
+	 * latitude using the visitor's IP address (if configured to do so).
+	 *
+	 * Allowed only for Admin/Super User, must be used along with setTokenAuth().
+	 *
+	 * @return $this
+	 */
+	public function setLatitude(float $lat)
+	{
+		$this->lat = $lat;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the longitude of the visitor. If not used, Matomo may try to find the visitor's
+	 * longitude using the visitor's IP address (if configured to do so).
+	 *
+	 * Allowed only for Admin/Super User, must be used along with setTokenAuth().
+	 *
+	 * @return $this
+	 */
+	public function setLongitude(float $long)
+	{
+		$this->long = $long;
+
+		return $this;
+	}
+
+	/**
+	 * Enables the bulk request feature. When used, each tracking action is stored until the
+	 * doBulkTrack method is called. This method will send all tracking data at once.
+	 */
+	public function enableBulkTracking(): void
+	{
+		$this->doBulkRequests = true;
+	}
+
+	/**
+	 * Disables the bulk request feature. Make sure to call `doBulkTrack()` before disabling it if you have stored
+	 * tracking actions previously as this method won't be sending any previously stored actions before disabling it.
+	 */
+	public function disableBulkTracking(): void
+	{
+		$this->doBulkRequests = false;
+	}
+
+	/**
+	 * Enable Cookie Creation - this will cause a first party VisitorId cookie to be set when the VisitorId is set or reset
+	 *
+	 * @param string $domain (optional) Set first-party cookie domain.
+	 *  Accepted values: example.com, *.example.com (same as .example.com) or subdomain.example.com
+	 * @param string $path (optional) Set first-party cookie path
+	 * @param bool $secure (optional) Set secure flag for cookies
+	 * @param bool $httpOnly (optional) Set HTTPOnly flag for cookies
+	 * @param string $sameSite (optional) Set SameSite flag for cookies
+	 */
+	public function enableCookies(
+		string $domain = '',
+		string $path = '/',
+		bool $secure = false,
+		bool $httpOnly = false,
+		string $sameSite = ''
+	): void {
+		$this->configCookiesDisabled = false;
+		$this->configCookieDomain = self::domainFixup($domain);
+		$this->configCookiePath = $path;
+		$this->configCookieSecure = $secure;
+		$this->configCookieHTTPOnly = $httpOnly;
+		$this->configCookieSameSite = $sameSite;
+	}
+
+	/**
+	 * If image response is disabled Matomo will respond with a HTTP 204 header instead of responding with a gif.
+	 */
+	public function disableSendImageResponse(): void
+	{
+		$this->sendImageResponse = false;
+	}
+
+	/**
+	 * Fix-up domain
+	 */
+	protected static function domainFixup($domain)
+	{
+		if (strlen($domain) > 0) {
+			$dl = strlen($domain) - 1;
+			// remove trailing '.'
+			if ($domain[$dl] === '.') {
+				$domain = substr($domain, 0, $dl);
+			}
+			// remove leading '*'
+			if (substr($domain, 0, 2) === '*.') {
+				$domain = substr($domain, 1);
+			}
+		}
+
+		return $domain;
+	}
+
+	/**
+	 * Get cookie name with prefix and domain hash
+	 */
+	protected function getCookieName(string $cookieName): string
+	{
+		// NOTE: If the cookie name is changed, we must also update the method in matomo.js with the same name.
+		$hash = substr(
+			sha1(
+				($this->configCookieDomain === ''
+					? self::getCurrentHost()
+					: $this->configCookieDomain
+				) . $this->configCookiePath
+			),
+			0,
+			4
+		);
+
+		return self::FIRST_PARTY_COOKIES_PREFIX . $cookieName . '.' . $this->idSite . '.' . $hash;
+	}
+
+	/**
+	 * Tracks a page view
+	 *
+	 * @param string $documentTitle Page title as it will appear in the Actions > Page titles report
+	 * @return mixed Response string or true if using bulk requests.
+	 */
+	public function doTrackPageView(string $documentTitle)
+	{
+		if (!$this->idPageviewSetManually) {
+			$this->generateNewPageviewId();
+		}
+
+		$url = $this->getUrlTrackPageView($documentTitle);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * If the current user agent belongs to an AI agent bot, tracks a pageview action.
+	 *
+	 * This method should be used server side to track AI bots that do not execute
+	 * JavaScript.
+	 *
+	 * @return mixed Response string or true if using bulk requests.
+	 */
+	public function doTrackPageViewIfAIBot(?int $httpStatus = null, ?int $responseSizeBytes = null, ?int $serverTimeMs = null, ?string $source = null)
+	{
+		if (!self::isUserAgentAIBot($this->userAgent)) {
+			return null;
+		}
+
+		$url = $this->getUrlTrackAIBot($httpStatus, $responseSizeBytes, $serverTimeMs, $source);
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Override PageView id for every use of `doTrackPageView()`. Do not use this if you call `doTrackPageView()`
+	 * multiple times during tracking (if, for example, you are tracking a single page application).
+	 */
+	public function setPageviewId(string $idPageview): void
+	{
+		$this->idPageview = $idPageview;
+		$this->idPageviewSetManually = true;
+	}
+
+	/**
+	 * Returns the PageView id. If the id was manually set using `setPageViewId()`, that id will be returned.
+	 * If the id was not set manually, the id that was automatically generated in last `doTrackPageView()` will
+	 * be returned. If there was no last page view, this will be false.
+	 *
+	 * @return string|false The PageView id as string or false if there is none yet.
+	 */
+	public function getPageviewId()
+	{
+		return $this->idPageview;
+	}
+
+	private function generateNewPageviewId(): void
+	{
+		$this->idPageview = substr(md5(uniqid(rand(), true)), 0, 6);
+	}
+
+	/**
+	 * Tracks an event
+	 *
+	 * @param string $category The Event Category (Videos, Music, Games...)
+	 * @param string $action The Event's Action (Play, Pause, Duration, Add Playlist, Downloaded, Clicked...)
+	 * @param string|bool $name (optional) The Event's object Name (a particular Movie name, or Song name, or File name...)
+	 * @param float|bool $value (optional) The Event's value
+	 * @return mixed Response string or true if using bulk requests.
+	 */
+	public function doTrackEvent(
+		string $category,
+		string $action,
+			   $name = false,
+			   $value = false
+	) {
+		$url = $this->getUrlTrackEvent($category, $action, $name, $value);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Tracks a content impression
+	 *
+	 * @param string $contentName The name of the content. For instance 'Ad Foo Bar'
+	 * @param string $contentPiece The actual content. For instance the path to an image, video, audio, any text
+	 * @param string|bool $contentTarget (optional) The target of the content. For instance the URL of a landing page.
+	 * @return mixed Response string or true if using bulk requests.
+	 */
+	public function doTrackContentImpression(
+		string $contentName,
+		string $contentPiece = 'Unknown',
+			   $contentTarget = false
+	) {
+		$url = $this->getUrlTrackContentImpression($contentName, $contentPiece, $contentTarget);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Tracks a content interaction. Make sure you have tracked a content impression using the same content name and
+	 * content piece, otherwise it will not count. To do so you should call the method doTrackContentImpression();
+	 *
+	 * @param string $interaction The name of the interaction with the content. For instance a 'click'
+	 * @param string $contentName The name of the content. For instance 'Ad Foo Bar'
+	 * @param string $contentPiece The actual content. For instance the path to an image, video, audio, any text
+	 * @param string|bool $contentTarget (optional) The target the content leading to when an interaction occurs. For instance the URL of a landing page.
+	 * @return mixed Response string or true if using bulk requests.
+	 */
+	public function doTrackContentInteraction(
+		string $interaction,
+		string $contentName,
+		string $contentPiece = 'Unknown',
+			   $contentTarget = false
+	) {
+		$url = $this->getUrlTrackContentInteraction($interaction, $contentName, $contentPiece, $contentTarget);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Tracks an internal Site Search query, and optionally tracks the Search Category, and Search results Count.
+	 * These are used to populate reports in Actions > Site Search.
+	 *
+	 * @param string $keyword Searched query on the site
+	 * @param string $category (optional) Search engine category if applicable
+	 * @param bool|int $countResults (optional) results displayed on the search result page. Used to track "zero result" keywords.
+	 *
+	 * @return mixed Response or true if using bulk requests.
+	 */
+	public function doTrackSiteSearch(
+		string $keyword,
+		string $category = '',
+			   $countResults = false
+	) {
+		$url = $this->getUrlTrackSiteSearch($keyword, $category, $countResults);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Records a Goal conversion
+	 *
+	 * @param int $idGoal Id Goal to record a conversion
+	 * @param float $revenue Revenue for this conversion
+	 * @return mixed Response or true if using bulk request
+	 */
+	public function doTrackGoal(int $idGoal, float $revenue = 0.0)
+	{
+		$url = $this->getUrlTrackGoal($idGoal, $revenue);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Tracks a download or outlink
+	 *
+	 * @param string $actionUrl URL of the download or outlink
+	 * @param string $actionType Type of the action: 'download' or 'link'
+	 * @return mixed Response or true if using bulk request
+	 */
+	public function doTrackAction(string $actionUrl, string $actionType)
+	{
+		// Referrer could be udpated to be the current URL temporarily (to mimic JS behavior)
+		$url = $this->getUrlTrackAction($actionUrl, $actionType);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Adds an item in the Ecommerce order.
+	 *
+	 * This should be called before doTrackEcommerceOrder(), or before doTrackEcommerceCartUpdate().
+	 * This function can be called for all individual products in the cart (or order).
+	 * SKU parameter is mandatory. Other parameters are optional (set to false if value not known).
+	 * Ecommerce items added via this function are automatically cleared when doTrackEcommerceOrder() or getUrlTrackEcommerceOrder() is called.
+	 *
+	 * @param string $sku (required) SKU, Product identifier
+	 * @param string $name (optional) Product name
+	 * @param string|array $category (optional) Product category, or array of product categories (up to 5 categories can be specified for a given product)
+	 * @param float|int $price (optional) Individual product price (supports integer and decimal prices)
+	 * @param int $quantity (optional) Product quantity. If not specified, will default to 1 in the Reports
+	 * @throws Exception
+	 * @return $this
+	 */
+	public function addEcommerceItem(
+		string $sku,
+		string $name = '',
+			   $category = '',
+			   $price = 0.0,
+		int $quantity = 1
+	) {
+		if (empty($sku)) {
+			throw new Exception("You must specify a SKU for the Ecommerce item");
+		}
+
+		$price = $this->forceDotAsSeparatorForDecimalPoint($price);
+
+		$this->ecommerceItems[] = array($sku, $name, $category, $price, $quantity);
+
+		return $this;
+	}
+
+	/**
+	 * Tracks a Cart Update (add item, remove item, update item).
+	 *
+	 * On every Cart update, you must call addEcommerceItem() for each item (product) in the cart,
+	 * including the items that haven't been updated since the last cart update.
+	 * Items which were in the previous cart and are not sent in later Cart updates will be deleted from the cart (in the database).
+	 *
+	 * @param float $grandTotal Cart grandTotal (typically the sum of all items' prices)
+	 * @return mixed Response or true if using bulk request
+	 */
+	public function doTrackEcommerceCartUpdate(float $grandTotal)
+	{
+		$url = $this->getUrlTrackEcommerceCartUpdate($grandTotal);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Sends all stored tracking actions at once. Only has an effect if bulk tracking is enabled.
+	 *
+	 * To enable bulk tracking, call enableBulkTracking().
+	 *
+	 * @throws Exception
+	 * @return string Response
+	 */
+	public function doBulkTrack()
+	{
+		if (empty($this->storedTrackingActions)) {
+			throw new Exception(
+				"Error:  you must call the function doTrackPageView or doTrackGoal from this class,
+                 before calling this method doBulkTrack()"
+			);
+		}
+
+		$data = ['requests' => $this->storedTrackingActions];
+
+		// token_auth is not required by default, except if bulk_requests_require_authentication=1
+		if (!empty($this->token_auth)) {
+			$data['token_auth'] = $this->token_auth;
+		}
+
+		$postData = json_encode($data);
+		$response = $this->sendRequest($this->getBaseUrl(), 'POST', $postData, $force = true);
+
+		$this->storedTrackingActions = [];
+
+		return $response;
+	}
+
+	/**
+	 * Tracks an Ecommerce order.
+	 *
+	 * If the Ecommerce order contains items (products), you must call first the addEcommerceItem() for each item in the order.
+	 * All revenues (grandTotal, subTotal, tax, shipping, discount) will be individually summed and reported in Matomo reports.
+	 * Only the parameters $orderId and $grandTotal are required.
+	 *
+	 * @param string|int $orderId (required) Unique Order ID.
+	 *                This will be used to count this order only once in the event the order page is reloaded several times.
+	 *                orderId must be unique for each transaction, even on different days, or the transaction will not be recorded by Matomo.
+	 * @param float $grandTotal (required) Grand Total revenue of the transaction (including tax, shipping, etc.)
+	 * @param float $subTotal (optional) Sub total amount, typically the sum of items prices for all items in this order (before Tax and Shipping costs are applied)
+	 * @param float $tax (optional) Tax amount for this order
+	 * @param float $shipping (optional) Shipping amount for this order
+	 * @param float $discount (optional) Discounted amount in this order
+	 * @return mixed Response or true if using bulk request
+	 */
+	public function doTrackEcommerceOrder(
+		$orderId,
+		float $grandTotal,
+		float $subTotal = 0.0,
+		float $tax = 0.0,
+		float $shipping = 0.0,
+		float $discount = 0.0
+	) {
+		$url = $this->getUrlTrackEcommerceOrder($orderId, $grandTotal, $subTotal, $tax, $shipping, $discount);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Tracks a PHP Throwable a crash (requires CrashAnalytics to be enabled in the target Matomo)
+	 *
+	 * @param Throwable $throwable (required) the throwable to track. The message, stack trace, file location and line number
+	 *                      of the crash are deduced from this parameter. The crash type is set to the class name of
+	 *                      the Throwable.
+	 * @param string|null $category (optional) a category value for this crash. This can be any information you want
+	 *                              to attach to the crash.
+	 * @return mixed Response or true if using bulk request
+	 */
+	public function doTrackPhpThrowable(Throwable $throwable, ?string $category = null)
+	{
+		$message = $throwable->getMessage();
+		$stack = $throwable->getTraceAsString();
+		$type = get_class($throwable);
+		$location = $throwable->getFile();
+		$line = $throwable->getLine();
+
+		return $this->doTrackCrash($message, $type, $category, $stack, $location, $line);
+	}
+
+	/**
+	 * Track a crash (requires CrashAnalytics to be enabled in the target Matomo)
+	 *
+	 * @param string $message (required) the error message.
+	 * @param string|null $type (optional) the error type, such as the class name of an Exception.
+	 * @param string|null $category (optional) a category value for this crash. This can be any information you want
+	 *                              to attach to the crash.
+	 * @param string|null $stack (optional) the stack trace of the crash.
+	 * @param string|null $location (optional) the source file URI where the crash originated.
+	 * @param int|null $line (optional) the source file line where the crash originated.
+	 * @param int|null $column (optional) the source file column where the crash originated.
+	 * @return mixed Response or true if using bulk request
+	 */
+	public function doTrackCrash(
+		string $message,
+		?string $type = null,
+		?string $category = null,
+		?string $stack = null,
+		?string $location = null,
+		?int $line = null,
+		?int $column = null
+	) {
+		$url = $this->getUrlTrackCrash($message, $type, $category, $stack, $location, $line, $column);
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Sends a ping request.
+	 *
+	 * Ping requests do not track new actions. If they are sent within the standard visit length (see global.ini.php),
+	 * they will extend the existing visit and the current last action for the visit. If after the standard visit length,
+	 * ping requests will create a new visit using the last action in the last known visit.
+	 *
+	 * @return mixed Response or true if using bulk request
+	 */
+	public function doPing()
+	{
+		$url = $this->getRequest($this->idSite);
+		$url .= '&ping=1';
+
+		return $this->sendRequest($url);
+	}
+
+	/**
+	 * Sets the current page view as an item (product) page view, or an Ecommerce Category page view.
+	 *
+	 * This must be called before doTrackPageView() on this product/category page.
+	 *
+	 * On a category page, you may set the parameter $category only and set the other parameters to false.
+	 *
+	 * Tracking Product/Category page views will allow Matomo to report on Product & Categories
+	 * conversion rates (Conversion rate = Ecommerce orders containing this product or category / Visits to the product or category)
+	 *
+	 * @param string $sku Product SKU being viewed
+	 * @param string $name Product Name being viewed
+	 * @param string|array $category Category being viewed. On a Product page, this is the product's category.
+	 *                                You can also specify an array of up to 5 categories for a given page view.
+	 * @param float $price Specify the price at which the item was displayed
+	 * @return $this
+	 */
+	public function setEcommerceView(
+		string $sku = '',
+		string $name = '',
+			   $category = '',
+		float $price = 0.0
+	) {
+		$this->ecommerceView = [];
+
+		if (!empty($category)) {
+			if (is_array($category)) {
+				$category = json_encode($category);
+			}
+		} else {
+			$category = "";
+		}
+		$this->ecommerceView['_pkc'] = $category;
+
+		if (!empty($price)) {
+			$price = $this->forceDotAsSeparatorForDecimalPoint($price);
+			$this->ecommerceView['_pkp'] = $price;
+		}
+
+		// On a category page, do not record "Product name not defined"
+		if (empty($sku) && empty($name)) {
+			return $this;
+		}
+		if (!empty($sku)) {
+			$this->ecommerceView['_pks'] = $sku;
+		}
+		if (empty($name)) {
+			$name = '';
+		}
+		$this->ecommerceView['_pkn'] = $name;
+
+		return $this;
+	}
+
+	/**
+	 * Force the separator for decimal point to be a dot. See https://github.com/matomo-org/matomo/issues/6435
+	 * If for instance a German locale is used it would be a comma otherwise.
+	 *
+	 * @param  float|string $value
+	 */
+	private function forceDotAsSeparatorForDecimalPoint($value): string
+	{
+		if (null === $value || false === $value) {
+			return $value;
+		}
+
+		return str_replace(',', '.', $value);
+	}
+
+	/**
+	 * TODO: tests
+	 * TODO: docs
+	 *
+	 * @return string
+	 */
+	public function getUrlTrackAIBot(?int $httpStatus = null, ?int $responseSizeBytes = null, ?int $serverTimeMs = null, ?string $source = null): string
+	{
+		$url = $this->getRequest($this->idSite);
+
+		$url .= '&recMode=1';
+
+		if (!empty($httpStatus)) {
+			$url .= '&http_status=' . $httpStatus;
+		}
+
+		if (!empty($responseSizeBytes)) {
+			$url .= '&bw_bytes=' . $responseSizeBytes;
+		}
+
+		if (!empty($serverTimeMs)) {
+			$url .= '&pf_srv=' . $serverTimeMs;
+		}
+
+		if (!empty($source)) {
+			$url .= '&source=' . rawurlencode($source);
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Returns URL used to track Ecommerce Cart updates
+	 * Calling this function will reinitializes the property ecommerceItems to empty array
+	 * so items will have to be added again via addEcommerceItem()
+	 * @ignore
+	 */
+	public function getUrlTrackEcommerceCartUpdate($grandTotal)
+	{
+		return $this->getUrlTrackEcommerce($grandTotal);
+	}
+
+	/**
+	 * Returns URL used to track Ecommerce Orders
+	 * Calling this function will reinitializes the property ecommerceItems to empty array
+	 * so items will have to be added again via addEcommerceItem()
+	 * @ignore
+	 */
+	public function getUrlTrackEcommerceOrder(
+		$orderId,
+		$grandTotal,
+		$subTotal = 0.0,
+		$tax = 0.0,
+		$shipping = 0.0,
+		$discount = 0.0
+	) {
+		if (empty($orderId)) {
+			throw new Exception("You must specifiy an orderId for the Ecommerce order");
+		}
+		$url = $this->getUrlTrackEcommerce($grandTotal, $subTotal, $tax, $shipping, $discount);
+		$url .= '&ec_id=' . urlencode($orderId);
+
+		return $url;
+	}
+
+	/**
+	 * Returns URL used to track Ecommerce orders
+	 *
+	 * Calling this function will reinitializes the property ecommerceItems to empty array
+	 * so items will have to be added again via addEcommerceItem()
+	 *
+	 * @ignore
+	 */
+	protected function getUrlTrackEcommerce($grandTotal, $subTotal = 0.0, $tax = 0.0, $shipping = 0.0, $discount = 0.0)
+	{
+		if (!is_numeric($grandTotal)) {
+			throw new Exception("You must specifiy a grandTotal for the Ecommerce order (or Cart update)");
+		}
+
+		$url = $this->getRequest($this->idSite);
+		$url .= '&idgoal=0';
+		if (!empty($grandTotal)) {
+			$grandTotal = $this->forceDotAsSeparatorForDecimalPoint($grandTotal);
+			$url .= '&revenue=' . $grandTotal;
+		}
+		if (!empty($subTotal)) {
+			$subTotal = $this->forceDotAsSeparatorForDecimalPoint($subTotal);
+			$url .= '&ec_st=' . $subTotal;
+		}
+		if (!empty($tax)) {
+			$tax = $this->forceDotAsSeparatorForDecimalPoint($tax);
+			$url .= '&ec_tx=' . $tax;
+		}
+		if (!empty($shipping)) {
+			$shipping = $this->forceDotAsSeparatorForDecimalPoint($shipping);
+			$url .= '&ec_sh=' . $shipping;
+		}
+		if (!empty($discount)) {
+			$discount = $this->forceDotAsSeparatorForDecimalPoint($discount);
+			$url .= '&ec_dt=' . $discount;
+		}
+		if (!empty($this->ecommerceItems)) {
+			$url .= '&ec_items=' . urlencode(json_encode($this->ecommerceItems));
+		}
+		$this->ecommerceItems = array();
+
+		return $url;
+	}
+
+	/**
+	 * Builds URL to track a page view.
+	 *
+	 * @see doTrackPageView()
+	 * @param string $documentTitle Page view name as it will appear in Matomo reports
+	 * @return string URL to matomo.php with all parameters set to track the pageview
+	 */
+	public function getUrlTrackPageView(string $documentTitle = ''): string
+	{
+		$url = $this->getRequest($this->idSite);
+		if (strlen($documentTitle) > 0) {
+			$url .= '&action_name=' . urlencode($documentTitle);
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Builds URL to track a custom event.
+	 *
+	 * @see doTrackEvent()
+	 * @param string $category The Event Category (Videos, Music, Games...)
+	 * @param string $action The Event's Action (Play, Pause, Duration, Add Playlist, Downloaded, Clicked...)
+	 * @param string|bool $name (optional) The Event's object Name (a particular Movie name, or Song name, or File name...)
+	 * @param float|bool $value (optional) The Event's value
+	 * @return string URL to matomo.php with all parameters set to track the pageview
+	 * @throws
+	 */
+	public function getUrlTrackEvent(
+		string $category,
+		string $action,
+			   $name = false,
+			   $value = false
+	): string {
+		$url = $this->getRequest($this->idSite);
+		if (strlen($category) === 0) {
+			throw new Exception("You must specify an Event Category name (Music, Videos, Games...).");
+		}
+		if (strlen($action) === 0) {
+			throw new Exception("You must specify an Event action (click, view, add...).");
+		}
+
+		$url .= '&e_c=' . urlencode($category);
+		$url .= '&e_a=' . urlencode($action);
+
+		if (strlen($name) > 0) {
+			$url .= '&e_n=' . urlencode($name);
+		}
+		if (strlen($value) > 0) {
+			$value = $this->forceDotAsSeparatorForDecimalPoint($value);
+			$url .= '&e_v=' . $value;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Builds URL to track a content impression.
+	 *
+	 * @see doTrackContentImpression()
+	 * @param string $contentName The name of the content. For instance 'Ad Foo Bar'
+	 * @param string $contentPiece The actual content. For instance the path to an image, video, audio, any text
+	 * @param string|false $contentTarget (optional) The target of the content. For instance the URL of a landing page.
+	 * @throws Exception In case $contentName is empty
+	 * @return string URL to matomo.php with all parameters set to track the pageview
+	 */
+	public function getUrlTrackContentImpression(
+		string $contentName,
+		string $contentPiece,
+			   $contentTarget
+	): string {
+		$url = $this->getRequest($this->idSite);
+
+		if (strlen($contentName) === 0) {
+			throw new Exception("You must specify a content name");
+		}
+
+		$url .= '&c_n=' . urlencode($contentName);
+
+		if (!empty($contentPiece) && strlen($contentPiece) > 0) {
+			$url .= '&c_p=' . urlencode($contentPiece);
+		}
+		if (!empty($contentTarget) && strlen($contentTarget) > 0) {
+			$url .= '&c_t=' . urlencode($contentTarget);
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Builds URL to track a content interaction.
+	 *
+	 * @see doTrackContentInteraction()
+	 * @param string $interaction The name of the interaction with the content. For instance a 'click'
+	 * @param string $contentName The name of the content. For instance 'Ad Foo Bar'
+	 * @param string $contentPiece The actual content. For instance the path to an image, video, audio, any text
+	 * @param string|false $contentTarget (optional) The target the content leading to when an interaction occurs. For instance the URL of a landing page.
+	 * @throws Exception In case $interaction or $contentName is empty
+	 * @return string URL to matomo.php with all parameters set to track the pageview
+	 */
+	public function getUrlTrackContentInteraction(
+		string $interaction,
+		string $contentName,
+		string $contentPiece,
+			   $contentTarget
+	): string {
+		$url = $this->getRequest($this->idSite);
+
+		if (strlen($interaction) === 0) {
+			throw new Exception("You must specify a name for the interaction");
+		}
+
+		if (strlen($contentName) === 0) {
+			throw new Exception("You must specify a content name");
+		}
+
+		$url .= '&c_i=' . urlencode($interaction);
+		$url .= '&c_n=' . urlencode($contentName);
+
+		if (!empty($contentPiece) && strlen($contentPiece) > 0) {
+			$url .= '&c_p=' . urlencode($contentPiece);
+		}
+		if (!empty($contentTarget) && strlen($contentTarget) > 0) {
+			$url .= '&c_t=' . urlencode($contentTarget);
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Builds URL to track a site search.
+	 *
+	 * @see doTrackSiteSearch()
+	 */
+	public function getUrlTrackSiteSearch(string $keyword, string $category, int $countResults): string
+	{
+		$url = $this->getRequest($this->idSite);
+		$url .= '&search=' . urlencode($keyword);
+		if (strlen($category) > 0) {
+			$url .= '&search_cat=' . urlencode($category);
+		}
+		if (!empty($countResults) || $countResults === 0) {
+			$url .= '&search_count=' . (int)$countResults;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Builds URL to track a goal with idGoal and revenue.
+	 *
+	 * @see doTrackGoal()
+	 * @param int $idGoal Id Goal to record a conversion
+	 * @param float $revenue Revenue for this conversion
+	 * @return string URL to matomo.php with all parameters set to track the goal conversion
+	 */
+	public function getUrlTrackGoal(int $idGoal, float $revenue = 0.0): string
+	{
+		$url = $this->getRequest($this->idSite);
+		$url .= '&idgoal=' . $idGoal;
+		if (!empty($revenue)) {
+			$revenue = $this->forceDotAsSeparatorForDecimalPoint($revenue);
+			$url .= '&revenue=' . $revenue;
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Builds URL to track a new action.
+	 *
+	 * @see doTrackAction()
+	 * @param string $actionUrl URL of the download or outlink
+	 * @param string $actionType Type of the action: 'download' or 'link'
+	 * @return string URL to matomo.php with all parameters set to track an action
+	 */
+	public function getUrlTrackAction(string $actionUrl, string $actionType): string
+	{
+		$url = $this->getRequest($this->idSite);
+		$url .= '&' . $actionType . '=' . urlencode($actionUrl);
+
+		return $url;
+	}
+
+	/**
+	 * Builds URL to track a crash.
+	 *
+	 * @see doTrackCrash()
+	 * @param string $message (required) the error message.
+	 * @param string|null $type (optional) the error type, such as the class name of an Exception.
+	 * @param string|null $category (optional) a category value for this crash. This can be any information you want
+	 *                              to attach to the crash.
+	 * @param string|null $stack (optional) the stack trace of the crash.
+	 * @param string|null $location (optional) the source file URI where the crash originated.
+	 * @param int|null $line (optional) the source file line where the crash originated.
+	 * @param int|null $column (optional) the source file column where the crash originated.
+	 * @return string URL to matomo.php with all parameters set to track an action
+	 */
+	public function getUrlTrackCrash(
+		string $message,
+		?string $type = null,
+		?string $category = null,
+		?string $stack = null,
+		?string $location = null,
+		?int $line = null,
+		?int $column = null
+	): string {
+		$url = $this->getRequest($this->idSite);
+		$url .= '&ca=1&cra=' . urlencode($message);
+		if ($type) {
+			$url .= '&cra_tp=' . urlencode($type);
+		}
+		if ($category) {
+			$url .= '&cra_ct=' . urlencode($category);
+		}
+		if ($stack) {
+			$url .= '&cra_st=' . urlencode($stack);
+		}
+		if ($location) {
+			$url .= '&cra_ru=' . urlencode($location);
+		}
+		if ($line) {
+			$url .= '&cra_rl=' . urlencode($line);
+		}
+		if ($column) {
+			$url .= '&cra_rc=' . urlencode($column);
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Overrides server date and time for the tracking requests.
+	 * By default Matomo will track requests for the "current datetime" but this function allows you
+	 * to track visits in the past. All times are in UTC.
+	 *
+	 * Allowed only for Admin/Super User, must be used along with setTokenAuth()
+	 * @see setTokenAuth()
+	 * @param string $dateTime Date with the format 'Y-m-d H:i:s', or a UNIX timestamp.
+	 *               If the datetime is older than one day (default value for tracking_requests_require_authentication_when_custom_timestamp_newer_than), then you must call setTokenAuth() with a valid Admin/Super user token.
+	 * @return $this
+	 */
+	public function setForceVisitDateTime(string $dateTime)
+	{
+		$this->forcedDatetime = $dateTime;
+
+		return $this;
+	}
+
+	/**
+	 * Forces Matomo to create a new visit for the tracking request.
+	 *
+	 * By default, Matomo will create a new visit if the last request by this user was more than 30 minutes ago.
+	 * If you call setForceNewVisit() before calling doTrack*, then a new visit will be created for this request.
+	 * @return $this
+	 */
+	public function setForceNewVisit()
+	{
+		$this->forcedNewVisit = true;
+
+		return $this;
+	}
+
+	/**
+	 * Overrides IP address
+	 *
+	 * Allowed only for Admin/Super User, must be used along with setTokenAuth()
+	 * @see setTokenAuth()
+	 * @param string $ip IP string, eg. 130.54.2.1
+	 * @return $this
+	 */
+	public function setIp(string $ip)
+	{
+		$this->ip = $ip;
+
+		return $this;
+	}
+
+	/**
+	 * Force the action to be recorded for a specific User. The User ID is a string representing a given user in your system.
+	 *
+	 * A User ID can be a username, UUID or an email address, or any number or string that uniquely identifies a user or client.
+	 *
+	 * @param string $userId Any user ID string (eg. email address, ID, username). Must be non empty. Set to false to de-assign a user id previously set.
+	 * @return $this
+	 * @throws Exception
+	 */
+	public function setUserId(string $userId)
+	{
+		if ($userId === '') {
+			throw new Exception("User ID cannot be empty.");
+		}
+		$this->userId = $userId;
+
+		return $this;
+	}
+
+	/**
+	 * Hash function used internally by Matomo to hash a User ID into the Visitor ID.
+	 *
+	 * Note: matches implementation of Tracker\Request->getUserIdHashed()
+	 *
+	 * @return string
+	 */
+	public static function getUserIdHashed($id): string
+	{
+		return substr(sha1($id), 0, 16);
+	}
+
+	/**
+	 * Forces the requests to be recorded for the specified Visitor ID.
+	 *
+	 * Rather than letting Matomo attribute the user with a heuristic based on IP and other user fingeprinting attributes,
+	 * force the action to be recorded for a particular visitor.
+	 *
+	 * If not set, the visitor ID will be fetched from the 1st party cookie, or will be set to a random UUID.
+	 *
+	 * @param string $visitorId 16 hexadecimal characters visitor ID, eg. "33c31e01394bdc63"
+	 * @return $this
+	 * @throws Exception
+	 */
+	public function setVisitorId(string $visitorId)
+	{
+		$hexChars = '01234567890abcdefABCDEF';
+		if (strlen($visitorId) !== self::LENGTH_VISITOR_ID
+			|| strspn($visitorId, $hexChars) !== strlen($visitorId)
+		) {
+			throw new Exception(
+				"setVisitorId() expects a "
+				. self::LENGTH_VISITOR_ID
+				. " characters hexadecimal string (containing only the following: "
+				. $hexChars
+				. ")"
+			);
+		}
+		$this->forcedVisitorId = $visitorId;
+
+		return $this;
+	}
+
+	/**
+	 * If the user initiating the request has the Matomo first party cookie,
+	 * this function will try and return the ID parsed from this first party cookie (found in $_COOKIE).
+	 *
+	 * If you call this function from a server, where the call is triggered by a cron or script
+	 * not initiated by the actual visitor being tracked, then it will return
+	 * the random Visitor ID that was assigned to this visit object.
+	 *
+	 * This can be used if you wish to record more visits, actions or goals for this visitor ID later on.
+	 *
+	 * @return string 16 hex chars visitor ID string
+	 */
+	public function getVisitorId()
+	{
+		if (!empty($this->forcedVisitorId)) {
+			return $this->forcedVisitorId;
+		}
+		if ($this->loadVisitorIdCookie()) {
+			return $this->cookieVisitorId;
+		}
+
+		return $this->randomVisitorId;
+	}
+
+	/**
+	 * Returns the currently set user agent.
+	 * @return string
+	 */
+	public function getUserAgent()
+	{
+		return $this->userAgent;
+	}
+
+	/**
+	 * Returns the currently set IP address.
+	 * @return string
+	 */
+	public function getIp()
+	{
+		return $this->ip;
+	}
+
+	/**
+	 * Returns the User ID string, which may have been set via:
+	 *     $v->setUserId('username@example.org');
+	 *
+	 * @return bool
+	 */
+	public function getUserId()
+	{
+		return $this->userId;
+	}
+
+	/**
+	 * Loads values from the VisitorId Cookie
+	 *
+	 * @return bool True if cookie exists and is valid, False otherwise
+	 */
+	protected function loadVisitorIdCookie(): bool
+	{
+		$idCookie = $this->getCookieMatchingName('id');
+		if ($idCookie === false) {
+			return false;
+		}
+		$parts = explode('.', $idCookie);
+		if (strlen($parts[0]) !== self::LENGTH_VISITOR_ID) {
+			return false;
+		}
+
+		/* $this->cookieVisitorId provides backward compatibility since getVisitorId()
+didn't change any existing VisitorId value */
+		$this->cookieVisitorId = $parts[0];
+		$this->createTs = $parts[1];
+
+		return true;
+	}
+
+	/**
+	 * Deletes all first party cookies from the client
+	 */
+	public function deleteCookies(): void
+	{
+		$cookies = array('id', 'ses', 'cvar', 'ref');
+		foreach ($cookies as $cookie) {
+			$this->setCookie($cookie, '', -86400);
+		}
+	}
+
+	/**
+	 * Returns the currently assigned Attribution Information stored in a first party cookie.
+	 *
+	 * This function will only work if the user is initiating the current request, and his cookies
+	 * can be read by PHP from the $_COOKIE array.
+	 *
+	 * @return string JSON Encoded string containing the Referrer information for Goal conversion attribution.
+	 *                Will return false if the cookie could not be found
+	 * @see matomo.js getAttributionInfo()
+	 */
+	public function getAttributionInfo()
+	{
+		if (!empty($this->attributionInfo)) {
+			return json_encode($this->attributionInfo);
+		}
+    }
+
+    /**
+     * Some Tracking API functionality requires express authentication, using either the
+     * Super User token_auth, or a user with 'admin' access to the website.
+     *
+     * The following features require access:
+     * - force the visitor IP
+     * - force the date &  time of the tracking requests rather than track for the current datetime
+     *
+     * @param string $token_auth token_auth 32 chars token_auth string
+     * @return $this
+     */
+    public function setTokenAuth(string $token_auth)
+    {
+        $this->token_auth = $token_auth;
+
+        return $this;
+    }
+
+    /**
+     * Sets local visitor time
+     *
+     * @param string $time HH:MM:SS format
+     * @return $this
+     */
+    public function setLocalTime(string $time)
+    {
+        [$hour, $minute, $second] = explode(':', $time);
+        $this->localHour = (int)$hour;
+        $this->localMinute = (int)$minute;
+        $this->localSecond = (int)$second;
+
+        return $this;
+    }
+
+    /**
+     * Sets user resolution width and height.
+     *
+     * @param int $width
+     * @param int $height
+     * @return $this
+     */
+    public function setResolution(int $width, int $height)
+    {
+        $this->width = $width;
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * Sets if the browser supports cookies
+     * This is reported in "List of plugins" report in Matomo.
+     *
+     * @return $this
+     */
+    public function setBrowserHasCookies(bool $hasCookies)
+    {
+        $this->hasCookies = $hasCookies;
+
+        return $this;
+    }
+
+    /**
+     * Will append a custom string at the end of the Tracking request.
+     *
+     * @return $this
+     */
+    public function setDebugStringAppend(string $debugString)
+    {
+        $this->DEBUG_APPEND_URL = '&' . $debugString;
+
+        return $this;
+    }
+
+    /**
+     * Sets visitor browser supported plugins
+     *
+     * @return $this
+     */
+    public function setPlugins(
+        bool $flash = false,
+        bool $java = false,
+        bool $quickTime = false,
+        bool $realPlayer = false,
+        bool $pdf = false,
+        bool $windowsMedia = false,
+        bool $silverlight = false
+    ) {
+        $this->plugins =
+            '&fla=' . (int)$flash .
+            '&java=' . (int)$java .
+            '&qt=' . (int)$quickTime .
+            '&realp=' . (int)$realPlayer .
+            '&pdf=' . (int)$pdf .
+            '&wma=' . (int)$windowsMedia .
+            '&ag=' . (int)$silverlight;
+
+        return $this;
+    }
+
+    /**
+     * By default, MatomoTracker will read first party cookies
+     * from the request and write updated cookies in the response (using setrawcookie).
+     * This can be disabled by calling this function.
+     */
+    public function disableCookieSupport(): void
+    {
+        $this->configCookiesDisabled = true;
+    }
+
+    /**
+     * Returns the maximum number of seconds the tracker will spend waiting for a response
+     * from Matomo. Defaults to 600 seconds.
+     */
+    public function getRequestTimeout(): int
+    {
+        return $this->requestTimeout;
+    }
+
+    /**
+     * Sets the maximum number of seconds that the tracker will spend waiting for a response
+     * from Matomo.
+     *
+     * @return $this
+     * @throws Exception
+     */
+    public function setRequestTimeout(int $timeout)
+    {
+        if ($timeout < 0) {
+            throw new Exception("Invalid value supplied for request timeout: $timeout");
+        }
+
+        $this->requestTimeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Returns the maximum number of seconds the tracker will spend trying to connect to Matomo.
+     * Defaults to 300 seconds.
+     */
+    public function getRequestConnectTimeout(): int
+    {
+        return $this->requestConnectTimeout;
+    }
+
+    /**
+     * Sets the maximum number of seconds that the tracker will spend tryint to connect to Matomo.
+     *
+     * @param int $timeout
+     * @return $this
+     * @throws Exception
+     */
+    public function setRequestConnectTimeout(int $timeout)
+    {
+        if ($timeout < 0) {
+            throw new Exception("Invalid value supplied for request connect timeout: $timeout");
+        }
+
+        $this->requestConnectTimeout = $timeout;
+
+        return $this;
+    }
+
+	/**
+     * Sets the request method to POST, which is recommended when using setTokenAuth()
+     * to prevent the token from being recorded in server logs. Avoid using redirects
+     * when using POST to prevent the loss of POST values. When using Log Analytics,
+     * be aware that POST requests are not parseable/replayable.
+     *
+     * @param string $method Either 'POST' or 'GET'
+     * @return $this
+     */
+    public function setRequestMethodNonBulk(string $method)
+    {
+        $this->requestMethod = strtoupper($method) === 'POST' ? 'POST' : 'GET';
+
+        return $this;
+    }
+
+    /**
+     * If a proxy is needed to look up the address of the Matomo site, set it with this
+     * @param string $proxy IP as string, for example "173.234.92.107"
+     */
+    public function setProxy(string $proxy, int $proxyPort = 80): void
+    {
+        $this->proxy = $proxy;
+        $this->proxyPort = $proxyPort;
+    }
+
+    /**
+     * If the proxy IP and the proxy port have been set, with the setProxy() function
+     * returns a string, like "173.234.92.107:80"
+     */
+    private function getProxy(): ?string
+    {
+        if (isset($this->proxy) && isset($this->proxyPort)) {
+            return $this->proxy.":".$this->proxyPort;
+        }
+        return null;
+    }
+
+    /**
+     * Used in tests to output useful error messages.
+     *
+     * @ignore
+     */
+    static public $DEBUG_LAST_REQUESTED_URL = false;
+
+    /**
+     * Returns array of curl options for request
+     *
+     * @return array<int, mixed>
+     */
+    protected function prepareCurlOptions(
+        string $url,
+        string $method,
+        $data,
+        bool $forcePostUrlEncoded
+    ): array {
+        $options = [
+            CURLOPT_URL => $url,
+            CURLOPT_USERAGENT => $this->userAgent,
+            CURLOPT_HEADER => true,
+            CURLOPT_TIMEOUT => $this->requestTimeout,
+            CURLOPT_CONNECTTIMEOUT => $this->requestConnectTimeout,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => [
+                'Accept-Language: ' . $this->acceptLanguage,
+            ],
+        ];
+
+        if ($method === 'GET') {
+            $options[CURLOPT_FOLLOWLOCATION] = true;
+        }
+
+        if (defined('PATH_TO_CERTIFICATES_FILE')) {
+            $options[CURLOPT_CAINFO] = PATH_TO_CERTIFICATES_FILE;
+        }
+
+        $proxy = $this->getProxy();
+        if (isset($proxy)) {
+            $options[CURLOPT_PROXY] = $proxy;
+        }
+
+        switch ($method) {
+            case 'POST':
+                $options[CURLOPT_POST] = true;
+                break;
+            default:
+                break;
+        }
+
+        // only supports JSON data
+        if (!empty($data) && $forcePostUrlEncoded) {
+            $options[CURLOPT_HTTPHEADER][] = 'Content-Type: application/x-www-form-urlencoded';
+            $options[CURLOPT_POSTFIELDS] = $data;
+            $options[CURLOPT_POST] = true;
+            if (defined('CURL_REDIR_POST_ALL')) {
+                $options[CURLOPT_POSTREDIR] = CURL_REDIR_POST_ALL;
+                $options[CURLOPT_FOLLOWLOCATION] = true;
+            }
+        } elseif (!empty($data)) {
+            $options[CURLOPT_HTTPHEADER][] = 'Content-Type: application/json';
+            $options[CURLOPT_HTTPHEADER][] = 'Expect:';
+            $options[CURLOPT_POSTFIELDS] = $data;
+        }
+
+        if (!empty($this->outgoingTrackerCookies)) {
+            $options[CURLOPT_COOKIE] = http_build_query($this->outgoingTrackerCookies);
+            $this->outgoingTrackerCookies = array();
+        }
+
+        return $options;
+    }
+
+    /**
+     * Returns array of stream options for request
+     *
+     * @return array{http: array<string, mixed>}
+     */
+    protected function prepareStreamOptions(string $method, $data, bool $forcePostUrlEncoded): array
+    {
+        $stream_options = [
+            'http' => [
+                'method' => $method,
+                'user_agent' => $this->userAgent,
+                'header' => "Accept-Language: " . $this->acceptLanguage . "\r\n",
+                'timeout' => $this->requestTimeout,
+            ],
+        ];
+
+        $proxy = $this->getProxy();
+        if (isset($proxy)) {
+            $stream_options['http']['proxy'] = $proxy;
+        }
+
+        // only supports JSON data
+        if (!empty($data) && $forcePostUrlEncoded) {
+            $stream_options['http']['header'] .= "Content-Type: application/x-www-form-urlencoded \r\n";
+            $stream_options['http']['content'] = $data;
+        } elseif (!empty($data)) {
+            $stream_options['http']['header'] .= "Content-Type: application/json \r\n";
+            $stream_options['http']['content'] = $data;
+        }
+
+        if (!empty($this->outgoingTrackerCookies)) {
+            $stream_options['http']['header'] .= 'Cookie: ' . http_build_query($this->outgoingTrackerCookies) . "\r\n";
+            $this->outgoingTrackerCookies = array();
+        }
+
+        return $stream_options;
+    }
+
+    /**
+     * @ignore
+     */
+    protected function sendRequest(string $url, string $method = 'GET', $data = null, bool $force = false): string
+    {
+        self::$DEBUG_LAST_REQUESTED_URL = $url;
+
+        // if doing a bulk request, store the url
+        if ($this->doBulkRequests && !$force) {
+            $this->storedTrackingActions[]
+                = $url
+                . (!empty($this->userAgent) ? ('&ua=' . urlencode($this->userAgent)) : '')
+                . (!empty($this->acceptLanguage) ? ('&lang=' . urlencode($this->acceptLanguage)) : '');
+
+            // Clear custom variables & dimensions so they don't get copied over to other users in the bulk request
+            $this->clearCustomVariables();
+            $this->clearCustomDimensions();
+            $this->clearCustomTrackingParameters();
+            $this->userAgent = false;
+            $this->clientHints = false;
+            $this->acceptLanguage = false;
+
+            return true;
+        }
+
+        $forcePostUrlEncoded = false;
+        if (!$this->doBulkRequests) {
+            if (!empty($this->requestMethod) && strtoupper($this->requestMethod) === 'POST') {
+                // POST ALL parameters and have no GET parameters
+                $urlParts = explode('?', $url);
+
+                $url = $urlParts[0];
+                $data = $urlParts[1];
+                $forcePostUrlEncoded = true;
+
+                $method = 'POST';
+            }
+
+            if (!empty($this->token_auth)) {
+                $appendTokenString = '&token_auth=' . urlencode($this->token_auth);
+
+                if (empty($this->requestMethod) || $method === 'POST') {
+                    // Only post token_auth but use GET URL parameters for everything else
+                    $forcePostUrlEncoded = true;
+                    if (empty($data)) {
+                        $data = '';
+                    }
+                    $data .= $appendTokenString;
+                    $data = ltrim($data, '&'); // when no request method set we don't want it to start with '&'
+                } elseif (!empty($this->token_auth)) {
+                    // Use GET for all URL parameters
+                    $url .= $appendTokenString;
+                }
+            }
+        }
+
+        $content = '';
+
+        if (function_exists('curl_init') && function_exists('curl_exec')) {
+            $options = $this->prepareCurlOptions($url, $method, $data, $forcePostUrlEncoded);
+
+            $ch = curl_init();
+            curl_setopt_array($ch, $options);
+            ob_start();
+            $response = @curl_exec($ch);
+
+            try {
+                $header = '';
+
+                if ($response === false) {
+                    $curlError = curl_error($ch);
+                    if (!empty($curlError)) {
+                        throw new \RuntimeException($curlError);
+                    }
+                }
+
+                if (!empty($response)) {
+                    // extract header
+                    $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+                    $header = substr($response, 0, $headerSize);
+
+                    // extract content
+                    $content = substr($response, $headerSize);
+                }
+
+                $this->parseIncomingCookies(explode("\r\n", $header));
+            } finally {
+                curl_close($ch);
+                ob_end_clean();
+            }
+        } elseif (function_exists('stream_context_create')) {
+            $stream_options = $this->prepareStreamOptions($method, $data, $forcePostUrlEncoded);
+
+            $ctx = stream_context_create($stream_options);
+            $response = file_get_contents($url, 0, $ctx);
+            $content = $response;
+
+            $this->parseIncomingCookies($http_response_header);
+        }
+
+        return $content;
+    }
+
+    /**
+     * Returns current timestamp, or forced timestamp/datetime if it was set
+     * @return string|int
+     */
+    protected function getTimestamp()
+    {
+        return !empty($this->forcedDatetime)
+            ? strtotime($this->forcedDatetime)
+            : time();
+    }
+
+    /**
+     * Returns the base URL for the Matomo server.
+     */
+    protected function getBaseUrl(): string
+    {
+        if (empty(self::$URL)) {
+            throw new Exception(
+                'You must first set the Matomo Tracker URL by calling
+                 MatomoTracker::$URL = \'http://your-website.org/matomo/\';'
+            );
+        }
+        if (strpos(self::$URL, '/matomo.php') === false
+            && strpos(self::$URL, '/proxy-matomo.php') === false
+        ) {
+            self::$URL = rtrim(self::$URL, '/');
+            self::$URL .= '/matomo.php';
+        }
+
+        return self::$URL;
+    }
+
+    /**
+     * @ignore
+     */
+    protected function getRequest(int $idSite): string
+    {
+        $this->setFirstPartyCookies();
+
+        $customFields = '';
+        if (!empty($this->customParameters)) {
+            $customFields = '&' . http_build_query($this->customParameters, '', '&');
+        }
+
+        $customDimensions = '';
+        if (!empty($this->customDimensions)) {
+            $customDimensions = '&' . http_build_query($this->customDimensions, '', '&');
+        }
+
+        $baseUrl = $this->getBaseUrl();
+        $start = '?';
+        if (strpos($baseUrl, '?') !== false) {
+            $start = '&';
+        }
+
+        $url = $baseUrl . $start .
+            'idsite=' . $idSite .
+            '&rec=1' .
+            '&apiv=' . self::VERSION .
+            '&r=' . substr(strval(mt_rand()), 2, 6) .
+
+            // XDEBUG_SESSIONS_START and KEY are related to the PHP Debugger, this can be ignored in other languages
+            (!empty($_GET['XDEBUG_SESSION_START']) ?
+                '&XDEBUG_SESSION_START=' . @urlencode($_GET['XDEBUG_SESSION_START']) : '') .
+            (!empty($_GET['KEY']) ? '&KEY=' . @urlencode($_GET['KEY']) : '') .
+
+            // Only allowed for Admin/Super User, token_auth required,
+            ((!empty($this->ip) && !empty($this->token_auth)) ? '&cip=' . $this->ip : '') .
+            (!empty($this->userId) ? '&uid=' . urlencode($this->userId) : '') .
+            (!empty($this->forcedDatetime) ? '&cdt=' . urlencode($this->forcedDatetime) : '') .
+            (!empty($this->forcedNewVisit) ? '&new_visit=1' : '') .
+
+            // Values collected from cookie
+            '&_idts=' . $this->createTs .
+
+            // These parameters are set by the JS, but optional when using API
+            (!empty($this->plugins) ? $this->plugins : '') .
+            (($this->localHour !== false && $this->localMinute !== false && $this->localSecond !== false) ?
+                '&h=' . $this->localHour . '&m=' . $this->localMinute . '&s=' . $this->localSecond : '') .
+            (!empty($this->width) && !empty($this->height) ? '&res=' . $this->width . 'x' . $this->height : '') .
+            (!empty($this->hasCookies) ? '&cookie=' . $this->hasCookies : '') .
+
+            // Various important attributes
+            (!empty($this->customData) ? '&data=' . $this->customData : '') .
+            (!empty($this->visitorCustomVar) ? '&_cvar=' . urlencode(json_encode($this->visitorCustomVar)) : '') .
+            (!empty($this->pageCustomVar) ? '&cvar=' . urlencode(json_encode($this->pageCustomVar)) : '') .
+            (!empty($this->eventCustomVar) ? '&e_cvar=' . urlencode(json_encode($this->eventCustomVar)) : '') .
+            (!empty($this->forcedVisitorId) ? '&cid=' . $this->forcedVisitorId : '&_id=' . $this->getVisitorId()) .
+
+            // URL parameters
+            '&url=' . urlencode($this->pageUrl ?? '') .
+            '&urlref=' . urlencode($this->urlReferrer ?? '') .
+            ((!empty($this->pageCharset) && $this->pageCharset != self::DEFAULT_CHARSET_PARAMETER_VALUES) ?
+                '&cs=' . $this->pageCharset : '') .
+
+            // unique pageview id
+            (!empty($this->idPageview) ? '&pv_id=' . urlencode($this->idPageview) : '') .
+
+            // Attribution information, so that Goal conversions are attributed to the right referrer or campaign
+            // Campaign name
+            (!empty($this->attributionInfo[0]) ? '&_rcn=' . urlencode($this->attributionInfo[0]) : '') .
+            // Campaign keyword
+            (!empty($this->attributionInfo[1]) ? '&_rck=' . urlencode($this->attributionInfo[1]) : '') .
+            // Timestamp at which the referrer was set
+            (!empty($this->attributionInfo[2]) ? '&_refts=' . $this->attributionInfo[2] : '') .
+            // Referrer URL
+            (!empty($this->attributionInfo[3]) ? '&_ref=' . urlencode($this->attributionInfo[3]) : '') .
+
+            // custom location info
+            (!empty($this->country) ? '&country=' . urlencode($this->country) : '') .
+            (!empty($this->region) ? '&region=' . urlencode($this->region) : '') .
+            (!empty($this->city) ? '&city=' . urlencode($this->city) : '') .
+            (!empty($this->lat) ? '&lat=' . urlencode($this->lat) : '') .
+            (!empty($this->long) ? '&long=' . urlencode($this->long) : '') .
+            $customFields . $customDimensions .
+            (!$this->sendImageResponse ? '&send_image=0' : '') .
+
+            // client hints
+            (!empty($this->clientHints) ? ('&uadata=' . urlencode(json_encode($this->clientHints))) : '') .
+
+            // DEBUG
+            $this->DEBUG_APPEND_URL;
+
+        if (!empty($this->idPageview)) {
+            $url .=
+                ($this->networkTime !== false ? '&pf_net=' . ((int)$this->networkTime) : '') .
+                ($this->serverTime !== false ? '&pf_srv=' . ((int)$this->serverTime) : '') .
+                ($this->transferTime !== false ? '&pf_tfr=' . ((int)$this->transferTime) : '') .
+                ($this->domProcessingTime !== false ? '&pf_dm1=' . ((int)$this->domProcessingTime) : '') .
+                ($this->domCompletionTime !== false ? '&pf_dm2=' . ((int)$this->domCompletionTime) : '') .
+                ($this->onLoadTime !== false ? '&pf_onl=' . ((int)$this->onLoadTime) : '');
+            $this->clearPerformanceTimings();
+        }
+
+        foreach ($this->ecommerceView as $param => $value) {
+            $url .= '&' . $param . '=' . urlencode($value);
+        }
+
+        // Reset page level custom variables after this page view
+        $this->ecommerceView = [];
+        $this->pageCustomVar = [];
+        $this->eventCustomVar = [];
+        $this->clearCustomDimensions();
+        $this->clearCustomTrackingParameters();
+
+        // force new visit only once, user must call again setForceNewVisit()
+        $this->forcedNewVisit = false;
+
+        return $url;
+    }
+
+
+    /**
+     * Returns a first party cookie which name contains $name
+     *
+     * @return string String value of cookie, or false if not found
+     * @ignore
+     */
+    protected function getCookieMatchingName(string $name)
+    {
+        if ($this->configCookiesDisabled) {
+            return false;
+        }
+        if (!is_array($_COOKIE)) {
+            return false;
+        }
+        $name = $this->getCookieName($name);
+
+        // Matomo cookie names use dots separators in matomo.js,
+        // but PHP Replaces . with _ http://www.php.net/manual/en/language.variables.predefined.php#72571
+        $name = str_replace('.', '_', $name);
+        foreach ($_COOKIE as $cookieName => $cookieValue) {
+            if (strpos($cookieName, $name) !== false) {
+                return $cookieValue;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * If current URL is "http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"
+     * will return "/dir1/dir2/index.php"
+     *
+     * @ignore
+     */
+    protected static function getCurrentScriptName(): string
+    {
+        $url = '';
+        if (!empty($_SERVER['PATH_INFO'])) {
+            $url = $_SERVER['PATH_INFO'];
+        } else {
+            if (!empty($_SERVER['REQUEST_URI'])) {
+                if (($pos = strpos($_SERVER['REQUEST_URI'], '?')) !== false) {
+                    $url = substr($_SERVER['REQUEST_URI'], 0, $pos);
+                } else {
+                    $url = $_SERVER['REQUEST_URI'];
+                }
+            }
+        }
+        if (empty($url) && isset($_SERVER['SCRIPT_NAME'])) {
+            $url = $_SERVER['SCRIPT_NAME'];
+        } elseif (empty($url)) {
+        	$url = '/';
+        }
+
+        if (!empty($url) && $url[0] !== '/') {
+            $url = '/' . $url;
+        }
+
+        return $url;
+    }
+
+    /**
+     * If the current URL is 'http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"
+     * will return 'http'
+     *
+     * @return string 'https' or 'http'
+     * @ignore
+     */
+    protected static function getCurrentScheme(): string
+    {
+        if (isset($_SERVER['HTTPS'])
+            && ($_SERVER['HTTPS'] === 'on' || $_SERVER['HTTPS'] === true)
+        ) {
+            return 'https';
+        }
+
+        return 'http';
+    }
+
+    /**
+     * If current URL is "http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"
+     * will return "http://example.org"
+     *
+     * @ignore
+     */
+    protected static function getCurrentHost(): string
+    {
+        if (isset($_SERVER['HTTP_HOST'])) {
+            return $_SERVER['HTTP_HOST'];
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * If current URL is "http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"
+     * will return "?param1=value1&param2=value2"
+     *
+     * @ignore
+     */
+    protected static function getCurrentQueryString(): string
+    {
+        $url = '';
+        if (isset($_SERVER['QUERY_STRING'])
+            && !empty($_SERVER['QUERY_STRING'])
+        ) {
+            $url .= '?' . $_SERVER['QUERY_STRING'];
+        }
+
+        return $url;
+    }
+
+    /**
+     * Returns the current full URL (scheme, host, path and query string.
+     *
+     * @ignore
+     */
+    protected static function getCurrentUrl(): string
+    {
+        return self::getCurrentScheme() . '://'
+        . self::getCurrentHost()
+        . self::getCurrentScriptName()
+        . self::getCurrentQueryString();
+    }
+
+    /**
+     * Sets the first party cookies as would the matomo.js
+     * All cookies are supported: 'id' and 'ses' and 'ref' and 'cvar' cookies.
+     * @return $this
+     */
+    protected function setFirstPartyCookies()
+    {
+        if ($this->configCookiesDisabled) {
+            return $this;
+        }
+
+        if (empty($this->cookieVisitorId)) {
+            $this->loadVisitorIdCookie();
+        }
+
+        // Set the 'ref' cookie
+        $attributionInfo = $this->getAttributionInfo();
+        if (!empty($attributionInfo)) {
+            $this->setCookie('ref', $attributionInfo, $this->configReferralCookieTimeout);
+        }
+
+        // Set the 'ses' cookie
+        $this->setCookie('ses', '*', $this->configSessionCookieTimeout);
+
+        // Set the 'id' cookie
+        $cookieValue = $this->getVisitorId() . '.' . $this->createTs;
+        $this->setCookie('id', $cookieValue, $this->configVisitorCookieTimeout);
+
+        // Set the 'cvar' cookie
+        $this->setCookie('cvar', json_encode($this->visitorCustomVar), $this->configSessionCookieTimeout);
+        return $this;
+    }
+
+    /**
+     * Sets a first party cookie to the client to improve dual JS-PHP tracking.
+     *
+     * This replicates the matomo.js tracker algorithms for consistency and better accuracy.
+     *
+     * @return $this
+     */
+    protected function setCookie(string $cookieName, $cookieValue, int $cookieTTL)
+    {
+        $cookieExpire = $this->currentTs + $cookieTTL;
+        if (!headers_sent()) {
+            $header = 'Set-Cookie: ' . rawurlencode($this->getCookieName($cookieName)) . '=' . rawurlencode($cookieValue)
+                . (empty($cookieExpire) ? '' : '; expires=' . gmdate('D, d-M-Y H:i:s', $cookieExpire) . ' GMT')
+                . (empty($this->configCookiePath) ? '' : '; path=' . $this->configCookiePath)
+                . (empty($this->configCookieDomain) ? '' : '; domain=' . rawurlencode($this->configCookieDomain))
+                . (!$this->configCookieSecure ? '' : '; secure')
+                . (!$this->configCookieHTTPOnly ? '' : '; HttpOnly')
+                . (!$this->configCookieSameSite ? '' : '; SameSite=' . rawurlencode($this->configCookieSameSite));
+
+            header($header, false);
+        }
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getCustomVariablesFromCookie()
+    {
+        $cookie = $this->getCookieMatchingName('cvar');
+        if (!$cookie) {
+            return [];
+        }
+
+        return json_decode($cookie, true);
+    }
+
+    /**
+     * Sets a cookie to be sent to the tracking server.
+     *
+     * @param $name
+     * @param $value
+     */
+    public function setOutgoingTrackerCookie($name, $value)
+    {
+        if ($value === null) {
+            unset($this->outgoingTrackerCookies[$name]);
+        }
+        else {
+            $this->outgoingTrackerCookies[$name] = $value;
+        }
+    }
+
+    /**
+     * Gets a cookie which was set by the tracking server.
+     *
+     * @param $name
+     *
+     * @return bool|string
+     */
+    public function getIncomingTrackerCookie($name)
+    {
+        if (isset($this->incomingTrackerCookies[$name])) {
+            return $this->incomingTrackerCookies[$name];
+        }
+
+        return false;
+    }
+
+    /**
+     * Reads incoming tracking server cookies.
+     *
+     * @param array $headers Array with HTTP response headers as values
+     */
+    protected function parseIncomingCookies(array $headers): void
+    {
+        $this->incomingTrackerCookies = [];
+
+        if (!empty($headers)) {
+            $headerName = 'set-cookie:';
+            $headerNameLength = strlen($headerName);
+
+            foreach($headers as $header) {
+                if (strpos(strtolower($header), $headerName) !== 0) {
+                    continue;
+                }
+                $cookies = trim(substr($header, $headerNameLength));
+                $posEnd = strpos($cookies, ';');
+                if ($posEnd !== false) {
+                    $cookies = substr($cookies, 0, $posEnd);
+                }
+                parse_str($cookies, $this->incomingTrackerCookies);
+            }
+        }
+    }
+
+    /**
+     * Returns true if the given user agent belongs to a known AI bot.
+     *
+     * @param string $userAgent
+     * @return bool
+     */
+    public static function isUserAgentAIBot(string $userAgent): bool
+    {
+        if (empty($userAgent)) {
+            return false;
+        }
+
+        foreach (self::AI_BOT_USER_AGENT_SUBSTRINGS as $substring) {
+            if (stripos($userAgent, $substring) !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/**
+ * Helper function to quickly generate the URL to track a page view.
+ *
+ * @param $idSite
+ * @param string $documentTitle
+ * @return string
+ */
+function Matomo_getUrlTrackPageView($idSite, $documentTitle = '')
+{
+    $tracker = new MatomoTracker($idSite);
+
+    return $tracker->getUrlTrackPageView($documentTitle);
+}
+
+/**
+ * Helper function to quickly generate the URL to track a goal.
+ *
+ * @param $idSite
+ * @param $idGoal
+ * @param float $revenue
+ * @return string
+ */
+function Matomo_getUrlTrackGoal($idSite, $idGoal, $revenue = 0.0)
+{
+    $tracker = new MatomoTracker($idSite);
+
+    return $tracker->getUrlTrackGoal($idGoal, $revenue);
+}
+
+/**
+ * Ensure PiwikTracker class is available as well
+ *
+ * @deprecated
+ */
+if (!class_exists('\WP_Piwik\PiwikTracker')) {
+    include_once('PiwikTracker.php');
+}

--- a/libs/matomo-php-tracker/PiwikTracker.php
+++ b/libs/matomo-php-tracker/PiwikTracker.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WP_Piwik {
+    /**
+     * Matomo - free/libre analytics platform
+     *
+     * For more information, see README.md
+     *
+     * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
+     * @link https://matomo.org/docs/tracking-api/
+     *
+     * @category Matomo
+     * @package MatomoTracker
+     */
+    if (!\class_exists('\\WP_Piwik\\MatomoTracker')) {
+        include_once 'MatomoTracker.php';
+    }
+    /**
+     * Helper function to quickly generate the URL to track a page view.
+     *
+     * @deprecated
+     * @param $idSite
+     * @param string $documentTitle
+     * @return string
+     */
+    function Piwik_getUrlTrackPageView($idSite, $documentTitle = '')
+    {
+        return \WP_Piwik\Matomo_getUrlTrackPageView($idSite, $documentTitle);
+    }
+    /**
+     * Helper function to quickly generate the URL to track a goal.
+     *
+     * @deprecated
+     * @param $idSite
+     * @param $idGoal
+     * @param float $revenue
+     * @return string
+     */
+    function Piwik_getUrlTrackGoal($idSite, $idGoal, $revenue = 0.0)
+    {
+        return \WP_Piwik\Matomo_getUrlTrackGoal($idSite, $idGoal, $revenue);
+    }
+    /**
+     * For BC only
+     *
+     * @deprecated use MatomoTracker instead
+     */
+    class PiwikTracker extends MatomoTracker
+    {
+    }
+}

--- a/libs/matomo-php-tracker/README.md
+++ b/libs/matomo-php-tracker/README.md
@@ -1,0 +1,53 @@
+# PHP Client for Matomo Analytics Tracking API
+
+The PHP Tracker Client provides all features of the [Matomo Javascript Tracker](https://developer.matomo.org/api-reference/tracking-javascript), such as Ecommerce Tracking, Custom Variables, Event Tracking and more. 
+
+## Documentation and examples 
+Check out our [Matomo-PHP-Tracker developer documentation](https://developer.matomo.org/api-reference/PHP-Piwik-Tracker) and [Matomo Tracking API guide](https://matomo.org/docs/tracking-api/).
+
+
+```php
+// Required variables
+$matomoSiteId = 6;                  // Site ID
+$matomoUrl = "https://example.tld"; // Your matomo URL
+$matomoToken = "";                  // Your authentication token
+
+// Optional variable
+$matomoPageTitle = "";              // The title of the page
+
+// Load object
+require_once("MatomoTracker.php");
+
+// Matomo object
+$matomoTracker = new MatomoTracker((int)$matomoSiteId, $matomoUrl);
+
+// Set authentication token
+$matomoTracker->setTokenAuth($matomoToken);
+
+// Track page view
+$matomoTracker->doTrackPageView($matomoPageTitle);
+```
+
+## Requirements:
+* JSON extension (json_decode, json_encode)
+* cURL or stream extension (to issue the HTTPS request to Matomo)
+
+## Installation
+
+### Composer
+
+```
+composer require matomo/matomo-php-tracker
+``` 
+
+### Manually
+
+Alternatively, you can download the files and require the Matomo tracker manually: 
+
+```
+require_once("MatomoTracker.php");
+```
+
+## License
+
+Released under the [BSD License](https://opensource.org/licenses/BSD-3-Clause)

--- a/libs/matomo-php-tracker/composer.json
+++ b/libs/matomo-php-tracker/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "matomo\/matomo-php-tracker",
+    "description": "PHP Client for Matomo Analytics Tracking API",
+    "keywords": [
+        "matomo",
+        "piwik",
+        "tracker",
+        "analytics"
+    ],
+    "homepage": "https:\/\/matomo.org",
+    "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "The Matomo Team",
+            "email": "hello@matomo.org",
+            "homepage": "https:\/\/matomo.org\/team\/"
+        }
+    ],
+    "support": {
+        "forum": "https:\/\/forum.matomo.org\/",
+        "issues": "https:\/\/github.com\/matomo-org\/matomo-php-tracker\/issues",
+        "source": "https:\/\/github.com\/matomo-org\/matomo-php-tracker"
+    },
+    "require": {
+        "php": "^7.2 || ^8.0",
+        "ext-json": "*"
+    },
+    "suggest": {
+        "ext-curl": "Using this extension to issue the HTTPS request to Matomo"
+    },
+    "autoload": {
+        "classmap": [
+            "."
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "\\": "tests\/"
+        }
+    },
+    "require-dev": {
+        "phpunit\/phpunit": "^8.5 || ^9.3 || ^10.1"
+    }
+}

--- a/libs/matomo-php-tracker/phpunit.xml.dist
+++ b/libs/matomo-php-tracker/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="true"
+         verbose="true">
+
+    <testsuites>
+        <testsuite name="UnitTests">
+            <directory>./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/misc/track_ai_bot.php
+++ b/misc/track_ai_bot.php
@@ -89,10 +89,12 @@ function wp_piwik_track_if_ai_bot() {
 		wp_plugin_directory_constants();
 	}
 
+	$url = !empty( $_REQUEST['mtm_url'] ) ? $_REQUEST['mtm_url'] : null;
+
 	$wpPiwik       = new \WP_Piwik();
 	$settings      = new \WP_Piwik\Settings( $wpPiwik );
 	$aiBotTracking = new \WP_Piwik\AIBotTracking( $settings, \WP_Piwik::getLogger() );
-	$aiBotTracking->doAiBotTracking();
+	$aiBotTracking->doAiBotTracking( $url );
 }
 
 register_shutdown_function( 'wp_piwik_track_if_ai_bot' );

--- a/misc/track_ai_bot.php
+++ b/misc/track_ai_bot.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+/*
+ * This script, when included or visited, will send an AI bot tracking
+ * request to Matomo in a shutdown function.
+ *
+ * It will only send this request if the current user agent is for a
+ * known AI bot.
+ *
+ * This script can be added to a user's wp-config.php or be executed
+ * via an HTTP request in an <esi:include> directive. It should have as
+ * few dependencies as possible, and load as few PHP file as possible.
+ */
+
+function wp_piwik_track_if_ai_bot() {
+	global $wpdb;
+
+	if (
+		( ! defined( 'WP_CACHE' ) || ! WP_CACHE )
+		&& empty( $_GET['mtm_esi'] )
+	) { // advanced-cache.php not in use and we are not tracking via esi:include
+		echo "abc?\n";
+		return;
+	}
+
+	if ( isset( $_GET['mtm_esi'] ) ) { // executing via esi:include directive
+		$GLOBALS['MATOMO_IN_AI_ESI'] = true;
+	}
+
+	require_once __DIR__ . '/../libs/matomo-php-tracker/MatomoTracker.php';
+
+	// check user agent is AI bot first thing, so if it is a normal request we do
+	// as little extra work as possible
+	$userAgent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+	if ( ! \WP_Piwik\MatomoTracker::isUserAgentAIBot( $userAgent ) ) {
+		return;
+	}
+
+	$GLOBALS['wp_plugin_paths'] = [];
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		// being called from a esi:include directive
+		define( 'SHORTINIT', true );
+
+		$wpConfigFile = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/wp-config.php';
+		if ( ! is_file( $wpConfigFile ) ) {
+			$wpConfigFile = dirname( dirname( dirname( dirname( dirname( $_SERVER['SCRIPT_FILENAME'] ) ) ) ) ) . '/wp-config.php';
+		}
+
+		require_once $wpConfigFile;
+	} else {
+		// being called from request that uses advanced-cache.php
+		require_once ABSPATH . WPINC . '/class-wp-list-util.php';
+		require_once ABSPATH . WPINC . '/class-wp-token-map.php';
+		require_once ABSPATH . WPINC . '/formatting.php';
+		require_once ABSPATH . WPINC . '/functions.php';
+	}
+
+	require_once ABSPATH . WPINC . '/link-template.php';
+	require_once ABSPATH . WPINC . '/general-template.php';
+	require_once ABSPATH . WPINC . '/http.php';
+	require_once ABSPATH . WPINC . '/class-wp-http.php';
+	require_once ABSPATH . WPINC . '/class-wp-http-streams.php';
+	require_once ABSPATH . WPINC . '/class-wp-http-curl.php';
+	require_once ABSPATH . WPINC . '/class-wp-http-proxy.php';
+	require_once ABSPATH . WPINC . '/class-wp-http-cookie.php';
+	require_once ABSPATH . WPINC . '/class-wp-http-encoding.php';
+	require_once ABSPATH . WPINC . '/class-wp-http-response.php';
+	require_once ABSPATH . WPINC . '/class-wp-http-requests-response.php';
+	require_once ABSPATH . WPINC . '/class-wp-http-requests-hooks.php';
+
+	require_once __DIR__ . '/../wp-piwik.php';
+
+	if ( empty( $wpdb ) ) {
+		require_wp_db();
+		wp_set_wpdb_vars();
+	}
+
+	wp_start_object_cache();
+
+	if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
+		wp_plugin_directory_constants();
+	}
+
+	$wpPiwik       = new \WP_Piwik();
+	$settings      = new \WP_Piwik\Settings( $wpPiwik );
+	$aiBotTracking = new \WP_Piwik\AIBotTracking( $settings, \WP_Piwik::getLogger() );
+	$aiBotTracking->doAiBotTracking();
+}
+
+register_shutdown_function( 'wp_piwik_track_if_ai_bot' );

--- a/misc/track_ai_bot.php
+++ b/misc/track_ai_bot.php
@@ -26,7 +26,6 @@ function wp_piwik_track_if_ai_bot() {
 		( ! defined( 'WP_CACHE' ) || ! WP_CACHE )
 		&& empty( $_GET['mtm_esi'] )
 	) { // advanced-cache.php not in use and we are not tracking via esi:include
-		echo "abc?\n";
 		return;
 	}
 

--- a/misc/track_ai_bot.php
+++ b/misc/track_ai_bot.php
@@ -16,7 +16,7 @@
  *
  * This script can be added to a user's wp-config.php or be executed
  * via an HTTP request in an <esi:include> directive. It should have as
- * few dependencies as possible, and load as few PHP file as possible.
+ * few dependencies as possible, and load as few PHP files as possible.
  */
 
 function wp_piwik_track_if_ai_bot() {

--- a/wp-piwik.php
+++ b/wp-piwik.php
@@ -36,8 +36,9 @@ if (! function_exists ( 'add_action' )) {
 	exit ();
 }
 
-if (! defined ( 'NAMESPACE_SEPARATOR' ))
+if (! defined ( 'NAMESPACE_SEPARATOR' )) {
 	define ( 'NAMESPACE_SEPARATOR', '\\' );
+}
 
 /**
  * Define WP-Piwik autoloader
@@ -48,7 +49,10 @@ if (! defined ( 'NAMESPACE_SEPARATOR' ))
 function wp_piwik_autoloader($class) {
 	if (substr ( $class, 0, 9 ) == 'WP_Piwik' . NAMESPACE_SEPARATOR) {
 		$class = str_replace ( '.', '', str_replace ( NAMESPACE_SEPARATOR, DIRECTORY_SEPARATOR, substr ( $class, 9 ) ) );
-		require_once ('classes' . DIRECTORY_SEPARATOR . 'WP_Piwik' . DIRECTORY_SEPARATOR . $class . '.php');
+		$file = 'classes' . DIRECTORY_SEPARATOR . 'WP_Piwik' . DIRECTORY_SEPARATOR . $class . '.php';
+		if ( is_file( __DIR__ . '/' . $file ) ) {
+			require_once $file;
+		}
 	}
 }
 
@@ -69,13 +73,15 @@ add_action( 'plugins_loaded', 'wp_piwik_load_textdomain' );
 if (version_compare ( PHP_VERSION, '5.3.0', '<' ))
 	add_action ( 'admin_notices', 'wp_piwik_phperror' );
 else {
+	define ( 'WP_PIWIK_FILE', __FILE__ );
 	define ( 'WP_PIWIK_PATH', dirname ( __FILE__ ) . DIRECTORY_SEPARATOR );
 	require_once (WP_PIWIK_PATH . 'config.php');
 	require_once (WP_PIWIK_PATH . 'classes' . DIRECTORY_SEPARATOR . 'WP_Piwik.php');
 	spl_autoload_register ( 'wp_piwik_autoloader' );
 	$GLOBALS ['wp-piwik_debug'] = false;
-	if (class_exists ( 'WP_Piwik' ))
-		add_action( 'init', 'wp_piwik_loader' );
+	if (class_exists ( 'WP_Piwik' )) {
+		add_action( 'setup_theme', 'wp_piwik_loader' );
+	}
 }
 
 function wp_piwik_loader() {


### PR DESCRIPTION
### Description

Feature related changes:

* Add two new settings: track AI bots and track AI bots using ESI (edge side includes).
* Implement server side AI bot tracking when no caching plugin is used.
* Implement server side AI bot tracking when a WordPress advanced cache is used.
* Display warning when .htaccess is used to serve cached files, since server side tracking cannot be done when this is used.
* Implement server side AI bot tracking that uses edge side includes to track AI bots when using a CDN or HTTP server that supports it (eg, Cloudflare or Litespeed web server).
* When AI bot tracking is enabled, add client side JS that will set a cookie if the current browser supports JavaScript. This cookie is only set for known AI bot crawlers. When the cookie is detected server side, we avoid sending a server side tracking request. This avoids, but does not eliminate, duplicate requests when an AI bot executes JavaScripts.
* When AI bot tracking is enabled, add recMode=2 to tracking URL client side so AI assistants that execute JS will automatically be detected by Matomo's tracking backend.



### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
