### PR TITLE
fix two issues in the Visitors widget

### DIFF
--- a/classes/WP_Piwik/Widget/Chart.php
+++ b/classes/WP_Piwik/Widget/Chart.php
@@ -14,7 +14,15 @@ class Chart extends Visitors
         $result = $this->requestData();
         $response = $result["response"];
         if (!$result["success"]) {
-            echo '<strong>' . __('Piwik error', 'wp-piwik') . ':</strong> ' . htmlentities($response[$method]['message'], ENT_QUOTES, 'utf-8');
+			$message = '';
+			foreach ($this->method as $m) {
+				if (empty($response[$m]['message'])) {
+					continue;
+				}
+
+				$message .= ' ' . $m . ' - ' . $response[$m]['message'];
+			}
+            echo '<strong>' . __('Piwik error', 'wp-piwik') . ':</strong> ' . htmlentities($message, ENT_QUOTES, 'utf-8');
         } else {
             $values = $labels = $bounced = $unique = '';
             $count = $uniqueSum = 0;

--- a/classes/WP_Piwik/Widget/Visitors.php
+++ b/classes/WP_Piwik/Widget/Visitors.php
@@ -12,10 +12,17 @@ class Visitors extends Widget
     protected function configure($prefix = '', $params = array())
     {
         $timeSettings = $this->getTimeSettings();
+
+        $lastN = $timeSettings['period'] == 'day' ? '30' : '12';
+        $piwikMode = \WP_Piwik::$wpPiwik->getGlobalOption('piwik_mode');
+        if ($piwikMode === 'cloud' || $piwikMode === 'cloud-matomo') {
+            $lastN = '1';
+        }
+
         $this->parameter = array(
             'idSite' => self::$wpPiwik->getPiwikSiteId($this->blogId),
             'period' => isset($params['period']) ? $params['period'] : $timeSettings['period'],
-            'date' => 'last' . ($timeSettings['period'] == 'day' ? '30' : '12'),
+            'date' => 'last' . $lastN,
             'limit' => null
         );
         $this->title = $prefix . __('Visitors', 'wp-piwik') . ' (' . __($this->rangeName(), 'wp-piwik') . ')';


### PR DESCRIPTION
### Description

Fixes MWP-939

Changes:
* the API response 'message' property is an array of strings, not a single string value, so concat the messages when an error occurs.
* Matomo Cloud only supports a lastN value of 1, so only use lastN=1 when the tracking mode is cloud.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
