### PR TITLE
delay creation of AjaxTracker instance until needed

### DIFF
--- a/classes/WP_Piwik/AIBotTracking.php
+++ b/classes/WP_Piwik/AIBotTracking.php
@@ -56,6 +56,11 @@ class AIBotTracking {
 	private $settings;
 
 	/**
+	 * @var Logger
+	 */
+	private $logger;
+
+	/**
 	 * @var AjaxTracker
 	 */
 	private $tracker;
@@ -66,8 +71,7 @@ class AIBotTracking {
 	 */
 	public function __construct( Settings $settings, Logger $logger ) {
 		$this->settings = $settings;
-		$this->tracker  = new AjaxTracker( $settings, $logger );
-		$this->tracker->setRequestTimeout( 1 );
+		$this->logger   = $logger;
 	}
 
 	public function registerHooks() {
@@ -132,10 +136,12 @@ class AIBotTracking {
 			$url = AjaxTracker::getCurrentUrl();
 		}
 
-		$this->tracker->setUrl( $url );
+		$tracker = $this->getTracker();
+
+		$tracker->setUrl( $url );
 
 		// cannot count bytes echo'd so no response size tracked
-		$this->tracker->doTrackPageViewIfAIBot( $responseCode, null, $requestElapsedMs, $source );
+		$tracker->doTrackPageViewIfAIBot( $responseCode, null, $requestElapsedMs, $source );
 	}
 
 	public function shouldTrackCurrentPage() {
@@ -200,7 +206,8 @@ class AIBotTracking {
 			return false;
 		}
 
-		if ( ! AjaxTracker::isUserAgentAIBot( $this->tracker->userAgent ) ) {
+		$tracker = $this->getTracker();
+		if ( ! AjaxTracker::isUserAgentAIBot( $tracker->userAgent ) ) {
 			return false;
 		}
 
@@ -212,5 +219,14 @@ class AIBotTracking {
 		}
 
 		return true;
+	}
+
+	private function getTracker() {
+		if ( empty( $this->tracker ) ) {
+			$this->tracker  = new AjaxTracker( $this->settings, $this->logger );
+			$this->tracker->setRequestTimeout( 1 );
+		}
+
+		return $this->tracker;
 	}
 }


### PR DESCRIPTION
### Description

As title. Mirrors change in MWP.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
