### PR TITLE
fix two more missing escape calls phpcs did not catch

### DIFF
--- a/classes/WP_Piwik/Widget.php
+++ b/classes/WP_Piwik/Widget.php
@@ -267,7 +267,7 @@ abstract class Widget {
 	 *            javascript code to apply
 	 */
 	private function tab_row( $trow, $java_script = '', $css_class = '' ) {
-		$this->out( '<tr' . ( ! empty( $java_script ) ? ' onclick="' . esc_attr( esc_js( $java_script ) ) . '"' : '' ) . ( ! empty( $css_class ) ? ' class="' . $css_class . '"' : '' ) . '>' );
+		$this->out( '<tr' . ( ! empty( $java_script ) ? ' onclick="' . esc_attr( esc_js( $java_script ) ) . '"' : '' ) . ( ! empty( $css_class ) ? ' class="' . esc_attr( $css_class ) . '"' : '' ) . '>' );
 		$count = 0;
 		foreach ( $trow as $tcell ) {
 			$this->out( '<td' . ( $count++ ? ' class="right"' : '' ) . '>' . esc_html( $tcell ) . '</td>' );

--- a/classes/WP_Piwik/Widget/Post.php
+++ b/classes/WP_Piwik/Widget/Post.php
@@ -58,7 +58,7 @@ class Post extends \WP_Piwik\Widget {
 					$response = $response[0];
 				}
 				if ( $this->parameter['key'] ) {
-					$this->out( isset( $response[ $this->parameter['key'] ] ) ? $response[ $this->parameter['key'] ] : '<em>not defined</em>' );
+					$this->out( isset( $response[ $this->parameter['key'] ] ) ? esc_html( $response[ $this->parameter['key'] ] ) : '<em>not defined</em>' );
 					return;
 				}
 			}


### PR DESCRIPTION
### Description

As title.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
