### PR TITLE
Require formatting include for wp_unslash

### DIFF
--- a/misc/track_ai_bot.php
+++ b/misc/track_ai_bot.php
@@ -39,7 +39,7 @@ function wp_piwik_track_if_ai_bot() {
 	// check user agent is AI bot first thing, so if it is a normal request we do
 	// as little extra work as possible
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '';
+	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? stripslashes( $_SERVER['HTTP_USER_AGENT'] ) : '';
 	if ( ! \WP_Piwik\MatomoTracker::isUserAgentAIBot( $user_agent ) ) {
 		return;
 	}
@@ -54,7 +54,7 @@ function wp_piwik_track_if_ai_bot() {
 		$wp_config_file = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/wp-config.php';
 		if ( ! is_file( $wp_config_file ) && ! empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
 			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$script_filename = wp_unslash( $_SERVER['SCRIPT_FILENAME'] );
+			$script_filename = stripslashes( $_SERVER['SCRIPT_FILENAME'] );
 			$wp_config_file  = dirname( dirname( dirname( dirname( dirname( $script_filename ) ) ) ) ) . '/wp-config.php';
 		}
 


### PR DESCRIPTION
### Description

Fixes a fatal error when wp_unslash is being called because the formatting include is being added after the method is called

PHP Fatal error: Uncaught Error: Call to undefined function wp_unslash() in /wp-content/plugins/wp-piwik/misc/track_ai_bot.php

### Checklist

- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
