### PR TITLE
make urlencoding of requests sent to Matomo consistent

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -58,7 +58,7 @@
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
 		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="PHPCompatibility.Lists.NewShortList.Found"/>
 		<exclude name="PHPCompatibility.Classes.NewAnonymousClasses.Found"/>
 		<exclude name="PHPCompatibility.InitialValue.NewConstantScalarExpressions.constFound"/>

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -406,7 +406,7 @@ class WP_Piwik {
 	 * @return string settings page URL
 	 */
 	private function get_settings_url() {
-		return ( self::$settings->check_network_activation() ? 'settings' : 'options-general' ) . '.php?page=' . self::$plugin_basename;
+		return ( self::$settings->check_network_activation() ? 'settings' : 'options-general' ) . '.php?page=wp-matomo-settings';
 	}
 
 	/**

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -56,9 +56,6 @@ class Settings extends \WP_Piwik\Admin {
 			if ( is_array( $piwik_version ) && isset( $piwik_version['value'] ) ) {
 				$piwik_version = $piwik_version['value'];
 			}
-			if ( ! empty( $piwik_version ) && ! is_array( $piwik_version ) ) {
-				$this->show_donation();
-			}
 		}
 		$page = sanitize_key( wp_unslash( $_GET['page'] ) );
 		?>
@@ -929,38 +926,6 @@ class Settings extends \WP_Piwik\Admin {
 				esc_html( $headline )
 			)
 			. ( $order > 0 ? '</h' . intval( $order ) . '>' : '' );
-	}
-
-	/**
-	 * Show donation info
-	 */
-	private function show_donation() {
-		?>
-<div class="wp-piwik-donate">
-	<p>
-		<strong><?php esc_html_e( 'Donate', 'wp-piwik' ); ?></strong>
-	</p>
-	<p>
-		<?php esc_html_e( 'If you like WP-Matomo, you can support its development by a donation:', 'wp-piwik' ); ?>
-	</p>
-	<div>
-		Paypal
-		<form action="https://www.paypal.com/cgi-bin/webscr" method="post">
-			<input type="hidden" name="cmd" value="_s-xclick" />
-			<input type="hidden" name="hosted_button_id" value="6046779" />
-			<input type="image" src="https://www.paypal.com/en_GB/i/btn/btn_donateCC_LG.gif" name="submit" alt="PayPal - The safer, easier way to pay online." />
-			<img alt="" border="0" src="https://www.paypal.com/de_DE/i/scr/pixel.gif" width="1" height="1" />
-		</form>
-	</div>
-	<div>
-		<a href="bitcoin:32FMBngRne9wQ7XPFP2CfR25tjp3oa4roN">Bitcoin<br />
-		<img style="border:none;" src="<?php echo esc_attr( self::$wp_piwik->get_plugin_url() ); ?>bitcoin.png" width="100" height="100" alt="Bitcoin Address" title="32FMBngRne9wQ7XPFP2CfR25tjp3oa4roN" /></a>
-	</div>
-	<div>
-		<a href="http://www.amazon.de/gp/registry/wishlist/111VUJT4HP1RA?reveal=unpurchased&amp;filter=all&amp;sort=priority&amp;layout=standard&amp;x=12&amp;y=14"><?php esc_html_e( 'My Amazon.de wishlist', 'wp-piwik' ); ?></a>
-	</div>
-</div>
-		<?php
 	}
 
 	/**

--- a/classes/WP_Piwik/Request.php
+++ b/classes/WP_Piwik/Request.php
@@ -105,12 +105,17 @@ abstract class Request {
 		return isset( self::$debug[ $id ] ) ? self::$debug[ $id ] : false;
 	}
 
-	protected function build_url( $config, $url_decode = false ) {
-		$url = 'method=' . ( $config['method'] ) . '&idSite=' . self::$settings->get_option( 'site_id' );
-		foreach ( $config['parameter'] as $key => $value ) {
-			$url .= '&' . $key . '=' . ( $url_decode ? rawurldecode( $value ) : $value );
-		}
-		return $url;
+	protected function build_url( $config ) {
+		return http_build_query( $this->get_url_params( $config ) );
+	}
+
+	protected function get_url_params( $config ) {
+		$params = [
+			'method' => $config['method'],
+			'idSite' => self::$settings->get_option( 'site_id' ),
+		];
+		$params = array_merge( $params, $config['parameter'] );
+		return $params;
 	}
 
 	protected function unserialize( $str ) {

--- a/classes/WP_Piwik/Request/Php.php
+++ b/classes/WP_Piwik/Request/Php.php
@@ -17,7 +17,9 @@ class Php extends \WP_Piwik\Request {
 				if ( '' !== self::$settings->get_global_option( 'filter_limit' ) && is_numeric( self::$settings->get_global_option( 'filter_limit' ) ) ) {
 					$config['parameter']['filter_limit'] = self::$settings->get_global_option( 'filter_limit' );
 				}
-				$params                          = 'module=API&format=json&' . $this->build_url( $config, true );
+				$params                          = $this->get_url_params( $config );
+				$params['module']                = 'API';
+				$params['format']                = 'json';
 				$map[ $count ]                   = $request_id;
 				$result                          = $this->call( $id, $url, $params );
 				self::$results[ $map[ $count ] ] = $result;
@@ -56,7 +58,8 @@ class Php extends \WP_Piwik\Request {
 			);
 		}
 		if ( class_exists( 'Piwik\API\Request' ) ) {
-			$request = new \Piwik\API\Request( $params . '&token_auth=' . self::$settings->get_global_option( 'piwik_token' ) );
+			$params['token_auth'] = self::$settings->get_global_option( 'piwik_token' );
+			$request              = new \Piwik\API\Request( $params );
 		} else {
 			return array(
 				'result'  => 'error',

--- a/classes/WP_Piwik/Widget/Post.php
+++ b/classes/WP_Piwik/Widget/Post.php
@@ -14,7 +14,7 @@ class Post extends \WP_Piwik\Widget {
 			'period'      => isset( $params['period'] ) ? $params['period'] : $time_settings['period'],
 			'date'        => isset( $params['date'] ) ? $params['date'] : $time_settings['date'],
 			'key'         => isset( $params['key'] ) ? $params['key'] : null,
-			'pageUrl'     => isset( $params['url'] ) ? $params['url'] : rawurlencode( get_permalink( $post->ID ) ),
+			'pageUrl'     => isset( $params['url'] ) ? $params['url'] : get_permalink( $post->ID ),
 			'description' => $time_settings['description'],
 		);
 		$this->title     = $prefix . esc_html__( 'Overview', 'wp-piwik' ) . ' (' . $this->parameter['date'] . ')';

--- a/css/wp-piwik.css
+++ b/css/wp-piwik.css
@@ -56,23 +56,6 @@ input.wp-piwik-wide {
 	width:100%;
 }
 
-div.wp-piwik-donate {
-	float:right;
-	width:220px;
-	background:#ffc;
-	padding:10px;
-	border:1px solid black;
-	margin: 10px 10px;
-}
-
-div.wp-piwik-donate div {
-	width:190px;
-	text-align:center;
-	border:solid black;
-	border-width:1px 0 0 0 ;
-	padding:5px
-}
-
 .wp-matomo-inline-notice {
     padding: 1em;
 }

--- a/misc/track_ai_bot.php
+++ b/misc/track_ai_bot.php
@@ -38,7 +38,8 @@ function wp_piwik_track_if_ai_bot() {
 
 	// check user agent is AI bot first thing, so if it is a normal request we do
 	// as little extra work as possible
-	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? stripslashes( $_SERVER['HTTP_USER_AGENT'] ) : '';
 	if ( ! \WP_Piwik\MatomoTracker::isUserAgentAIBot( $user_agent ) ) {
 		return;
@@ -54,6 +55,7 @@ function wp_piwik_track_if_ai_bot() {
 		$wp_config_file = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/wp-config.php';
 		if ( ! is_file( $wp_config_file ) && ! empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
 			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			$script_filename = stripslashes( $_SERVER['SCRIPT_FILENAME'] );
 			$wp_config_file  = dirname( dirname( dirname( dirname( dirname( $script_filename ) ) ) ) ) . '/wp-config.php';
 		}


### PR DESCRIPTION
### Description

Instead of assuming values are urlencoded when creating a URL supplied to Matomo's Piwik\API\Request class, assume they are not encoded. Callers no longer manually encode parameter values.

Other changes:
* Remove donation section.
* Fix settings URL in installation notice.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
