### PR TITLE
escape debug content properly

### DIFF
--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -1158,11 +1158,11 @@ class Settings extends \WP_Piwik\Admin {
 			$GLOBALS ['wp-piwik_debug'] = true;
 			$id                         = \WP_Piwik\Request::register( 'API.getPiwikVersion', array() );
 			echo "\n\n";
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
-			var_dump( self::$wp_piwik->request( $id ) );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			echo esc_textarea( var_export( self::$wp_piwik->request( $id ), true ) );
 			echo "\n";
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
-			var_dump( self::$wp_piwik->request( $id, true ) );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			echo esc_textarea( var_export( self::$wp_piwik->request( $id, true ), true ) );
 			echo "\n";
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 			$GLOBALS ['wp-piwik_debug'] = false;
@@ -1173,11 +1173,11 @@ class Settings extends \WP_Piwik\Admin {
 			$GLOBALS ['wp-piwik_debug'] = true;
 			$id                         = \WP_Piwik\Request::register( 'SitesManager.getSitesWithAtLeastViewAccess', array() );
 			echo "\n\n";
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
-			var_dump( self::$wp_piwik->request( $id ) );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			echo esc_textarea( var_export( self::$wp_piwik->request( $id ), true ) );
 			echo "\n";
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
-			var_dump( self::$wp_piwik->request( $id, true ) );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			echo esc_textarea( var_export( self::$wp_piwik->request( $id, true ), true ) );
 			echo "\n";
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 			$GLOBALS ['wp-piwik_debug'] = false;
@@ -1193,15 +1193,15 @@ class Settings extends \WP_Piwik\Admin {
 				)
 			);
 			echo "\n\n";
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
-			var_dump( self::$wp_piwik->request( $id ) );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			echo esc_textarea( var_export( self::$wp_piwik->request( $id ), true ) );
 			echo "\n";
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
-			var_dump( self::$wp_piwik->request( $id, true ) );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			echo esc_textarea( var_export( self::$wp_piwik->request( $id, true ), true ) );
 			echo "\n";
 			echo "\n\n";
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_dump
-			var_dump( self::$settings->get_debug_data() );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			echo esc_textarea( var_export( self::$settings->get_debug_data(), true ) );
 			echo '`';
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 			$GLOBALS ['wp-piwik_debug'] = false;


### PR DESCRIPTION
### Description

As title.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
