### PR TITLE
bump version to force wordpress.org to release a new plugin archive

### DIFF
--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -11,7 +11,7 @@ use WP_Piwik\Widget\Post;
 class WP_Piwik {
 
 	private static $revision_id = 2023092201;
-	private static $version     = '1.1.7';
+	private static $version     = '1.1.8';
 	private static $blog_id;
 	private static $plugin_basename = null;
 	private static $logger;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: Braekling
 Requires at least: 5.0
 Tested up to: 7.0.0
-Stable tag: 1.1.7
+Stable tag: 1.1.8
 Tags: matomo, tracking, statistics, stats, analytics
 
 Adds Matomo (former Piwik) statistics to your WordPress dashboard and is also able to add the Matomo Tracking Code to your blog.
@@ -145,6 +145,9 @@ Add WP-Matomo to your /wp-content/plugins folder and enable it as [Network Plugi
 5. Matomo: Here you'll find your auth token.
 
 == Changelog ==
+
+= 1.1.8 =
+* Dummy release to force wordpress.org to rebuild the plugin package.
 
 = 1.1.7 =
 * Bug fix: correctly escape output used to troubleshoot connection issues.

--- a/wp-piwik.php
+++ b/wp-piwik.php
@@ -3,7 +3,7 @@
  * Plugin Name: Connect Matomo
  * Plugin URI: http://wordpress.org/extend/plugins/wp-piwik/
  * Description: Adds Matomo statistics to your WordPress dashboard and is also able to add the Matomo Tracking Code to your blog.
- * Version: 1.1.7
+ * Version: 1.1.8
  * Author: Matomo, Andr&eacute; Br&auml;kling
  * Author URI: https://matomo.org
  * Text Domain: wp-piwik


### PR DESCRIPTION
### Description

It seems that if a plugin has release confirmations enabled, wordpress.org will not rebuild the plugin package if a svn commit changes things, so a new release is required to fix the 1.1.7/1.1.6 mismatch.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
