### PR TITLE
default to using POST for bulk requests to Matomo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 .phpunit.result.cache
 
 tests/phpunit/proxy/mock/runtime/
+tests/phpunit/rest/mock/runtime/

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -605,7 +605,7 @@ class Settings extends \WP_Piwik\Admin {
 				'post' => __( 'POST', 'wp-piwik' ),
 				'get'  => __( 'GET', 'wp-piwik' ),
 			),
-			__( 'Choose whether WP-Matomo should use POST or GET in HTTP or Cloud mode.', 'wp-piwik' )
+			__( 'Choose whether WP-Matomo should use POST or GET in HTTP or Cloud mode. POST is recommended: it keeps the auth token out of server access logs and is not subject to URL length limits.', 'wp-piwik' )
 		);
 
 		$this->show_checkbox( 'disable_timelimit', __( 'Disable time limit', 'wp-piwik' ), __( 'Use set_time_limit(0) if stats page causes a time out.', 'wp-piwik' ) );
@@ -1037,7 +1037,7 @@ class Settings extends \WP_Piwik\Admin {
 				esc_html_e( 'enabled', 'wp-piwik' );
 			?>
 			</strong>.</li>
-			<li><strong><?php echo ( ( ( function_exists( 'curl_init' ) && ini_get( 'allow_url_fopen' ) && 'curl' === self::$settings->get_global_option( 'http_connection' ) ) || ( function_exists( 'curl_init' ) && ! ini_get( 'allow_url_fopen' ) ) ) ? esc_html__( 'cURL', 'wp-piwik' ) : esc_html__( 'fopen', 'wp-piwik' ) ) . ' (' . ( 'post' === self::$settings->get_global_option( 'http_method' ) ? esc_html__( 'POST', 'wp-piwik' ) : esc_html__( 'GET', 'wp-piwik' ) ) . ')</strong> ' . esc_html__( 'is used.', 'wp-piwik' ); ?></li>
+			<li><strong><?php echo ( ( ( function_exists( 'curl_init' ) && ini_get( 'allow_url_fopen' ) && 'curl' === self::$settings->get_global_option( 'http_connection' ) ) || ( function_exists( 'curl_init' ) && ! ini_get( 'allow_url_fopen' ) ) ) ? esc_html__( 'cURL', 'wp-piwik' ) : esc_html__( 'fopen', 'wp-piwik' ) ) . ' (' . ( 'get' === self::$settings->get_global_option( 'http_method' ) ? esc_html__( 'GET', 'wp-piwik' ) : esc_html__( 'POST', 'wp-piwik' ) ) . ')</strong> ' . esc_html__( 'is used.', 'wp-piwik' ); ?></li>
 			<?php
 			if ( 'php' === self::$settings->get_global_option( 'piwik_mode' ) ) {
 				?>

--- a/classes/WP_Piwik/Request/Php.php
+++ b/classes/WP_Piwik/Request/Php.php
@@ -74,9 +74,22 @@ class Php extends \WP_Piwik\Request {
 		}
 		$result = $this->unserialize( $result );
 		if ( $GLOBALS ['wp-piwik_debug'] ) {
-			self::$debug[ $id ] = array( $params . '&token_auth=...' );
+			self::$debug[ $id ] = [ $this->build_debug_params( $params ) ];
 		}
 		return $result;
+	}
+
+	/**
+	 * Render the parameters of a request for debug output, with the auth token masked.
+	 *
+	 * @param array $params request parameters, including the auth token.
+	 * @return string
+	 */
+	protected function build_debug_params( $params ) {
+		if ( isset( $params['token_auth'] ) ) {
+			$params['token_auth'] = '...';
+		}
+		return http_build_query( $params, '', '&' );
 	}
 
 	public function reset() {

--- a/classes/WP_Piwik/Request/Rest.php
+++ b/classes/WP_Piwik/Request/Rest.php
@@ -3,7 +3,7 @@
 namespace WP_Piwik\Request;
 
 /**
- * TODO: switch to wp_remote_get
+ * TODO: switch to wp_remote_request
  * phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_close
  * phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_getinfo
  * phpcs:disable WordPress.WP.AlternativeFunctions.curl_curl_error
@@ -15,25 +15,9 @@ namespace WP_Piwik\Request;
 class Rest extends \WP_Piwik\Request {
 
 	protected function request( $id ) {
-		$count  = 0;
-		$url    = self::$settings->get_matomo_url();
-		$params = 'module=API&method=API.getBulkRequest&format=json';
-
-		$filter_limit = self::$settings->get_global_option( 'filter_limit' );
-		if (
-			$filter_limit > 0
-			&& is_numeric( self::$settings->get_global_option( 'filter_limit' ) )
-		) {
-			$params .= '&filter_limit=' . self::$settings->get_global_option( 'filter_limit' );
-		}
-		foreach ( self::$requests as $request_id => $config ) {
-			if ( ! isset( self::$results[ $request_id ] ) ) {
-				$params       .= '&urls[' . $count . ']=' . rawurlencode( $this->build_url( $config ) );
-				$map[ $count ] = $request_id;
-				++$count;
-			}
-		}
-		$use_curl = (
+		list( $params, $map ) = $this->build_bulk_params();
+		$url                  = self::$settings->get_matomo_url();
+		$use_curl             = (
 			function_exists( 'curl_init' )
 			&& ini_get( 'allow_url_fopen' )
 			&& 'curl' === self::$settings->get_global_option( 'http_connection' )
@@ -41,7 +25,7 @@ class Rest extends \WP_Piwik\Request {
 			function_exists( 'curl_init' )
 			&& ! ini_get( 'allow_url_fopen' )
 		);
-		$results  = $use_curl ? $this->curl( $id, $url, $params ) : $this->fopen( $id, $url, $params );
+		$results              = $use_curl ? $this->curl( $id, $url, $params ) : $this->fopen( $id, $url, $params );
 		if ( is_array( $results ) ) {
 			foreach ( $results as $num => $result ) {
 				if ( isset( $map[ $num ] ) ) {
@@ -51,13 +35,49 @@ class Rest extends \WP_Piwik\Request {
 		}
 	}
 
+	protected function build_bulk_params() {
+		$count  = 0;
+		$map    = [];
+		$params = [
+			'module' => 'API',
+			'method' => 'API.getBulkRequest',
+			'format' => 'json',
+		];
+
+		$filter_limit = self::$settings->get_global_option( 'filter_limit' );
+		if (
+			$filter_limit > 0
+			&& is_numeric( $filter_limit )
+		) {
+			$params['filter_limit'] = $filter_limit;
+		}
+		$params['urls'] = [];
+		foreach ( self::$requests as $request_id => $config ) {
+			if ( ! isset( self::$results[ $request_id ] ) ) {
+				$params['urls'][ $count ] = $this->build_url( $config );
+				$map[ $count ]            = $request_id;
+				++$count;
+			}
+		}
+		return [ $params, $map ];
+	}
+
+	protected function build_param_string( $params, $mask_token = false ) {
+		$params['token_auth'] = $mask_token ? '...' : self::$settings->get_global_option( 'piwik_token' );
+		return http_build_query( $params, '', '&' );
+	}
+
+	protected function should_use_post() {
+		return 'get' !== self::$settings->get_global_option( 'http_method' );
+	}
+
 	private function curl( $id, $url, $params ) {
-		if ( 'post' === self::$settings->get_global_option( 'http_method' ) ) {
+		if ( $this->should_use_post() ) {
 			$c = curl_init( $url );
 			curl_setopt( $c, CURLOPT_POST, 1 );
-			curl_setopt( $c, CURLOPT_POSTFIELDS, $params . '&token_auth=' . self::$settings->get_global_option( 'piwik_token' ) );
+			curl_setopt( $c, CURLOPT_POSTFIELDS, $this->build_param_string( $params ) );
 		} else {
-			$c = curl_init( $url . '?' . $params . '&token_auth=' . self::$settings->get_global_option( 'piwik_token' ) );
+			$c = curl_init( $url . '?' . $this->build_param_string( $params ) );
 		}
 		curl_setopt( $c, CURLOPT_SSL_VERIFYPEER, ! self::$settings->get_global_option( 'disable_ssl_verify' ) );
 		curl_setopt( $c, CURLOPT_SSL_VERIFYHOST, ! self::$settings->get_global_option( 'disable_ssl_verify_host' ) ? 2 : 0 );
@@ -73,54 +93,80 @@ class Rest extends \WP_Piwik\Request {
 				curl_setopt( $c, CURLOPT_PROXYUSERPWD, $http_proxy_class->username() . ':' . $http_proxy_class->password() );
 			}
 		}
-		$result           = curl_exec( $c );
+		$response         = curl_exec( $c );
 		self::$last_error = curl_error( $c );
+		$body             = is_string( $response ) ? $response : '';
 		if ( $GLOBALS ['wp-piwik_debug'] ) {
 			$header_size        = curl_getinfo( $c, CURLINFO_HEADER_SIZE );
-			$header             = substr( $result, 0, $header_size );
-			$body               = substr( $result, $header_size );
-			$result             = $this->unserialize( $body );
-			self::$debug[ $id ] = array( $header, $url . '?' . $params . '&token_auth=...' );
-		} else {
-			$result = $this->unserialize( $result );
+			$header             = substr( $body, 0, $header_size );
+			$body               = substr( $body, $header_size );
+			self::$debug[ $id ] = [ $header, ( $this->should_use_post() ? 'POST ' : 'GET ' ) . $url . ' ' . $this->build_param_string( $params, true ) ];
 		}
+		if ( '' === self::$last_error ) {
+			// curl only reports transport failures, so an unusable body still needs checking
+			self::$last_error = $this->check_response( false === $response ? false : $body, 'HTTP ' . curl_getinfo( $c, CURLINFO_HTTP_CODE ) );
+		}
+		$result = $this->unserialize( $body );
 		if ( version_compare( PHP_VERSION, '8', '<' ) ) {
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated
 			curl_close( $c );
 		}
 		return $result;
 	}
 
 	private function fopen( $id, $url, $params ) {
-		$context_definition        = array(
-			'http' => array(
+		$context_definition        = [
+			'http' => [
 				'timeout' => self::$settings->get_global_option( 'connection_timeout' ),
 				'header'  => "Content-type: application/x-www-form-urlencoded\r\n",
-			),
-		);
-		$context_definition['ssl'] = array();
+			],
+		];
+		$context_definition['ssl'] = [];
 		if ( self::$settings->get_global_option( 'disable_ssl_verify' ) ) {
-			$context_definition['ssl'] = array(
+			$context_definition['ssl'] = [
 				'allow_self_signed' => true,
 				'verify_peer'       => false,
-			);
+			];
 		}
 		if ( self::$settings->get_global_option( 'disable_ssl_verify_host' ) ) {
 			$context_definition['ssl']['verify_peer_name'] = false;
 		}
-		if ( self::$settings->get_global_option( 'http_method' ) === 'post' ) {
+		if ( $this->should_use_post() ) {
 			$full_url                              = $url;
 			$context_definition['http']['method']  = 'POST';
-			$context_definition['http']['content'] = $params . '&token_auth=' . self::$settings->get_global_option( 'piwik_token' );
+			$context_definition['http']['content'] = $this->build_param_string( $params );
 		} else {
-			$full_url = $url . '?' . $params . '&token_auth=' . self::$settings->get_global_option( 'piwik_token' );
+			$full_url = $url . '?' . $this->build_param_string( $params );
 		}
 		$context = stream_context_create( $context_definition );
 
+		$http_response_header = [];
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$result = $this->unserialize( @file_get_contents( $full_url, false, $context ) );
+		$response         = @file_get_contents( $full_url, false, $context );
+		self::$last_error = $this->check_response( $response, isset( $http_response_header[0] ) ? $http_response_header[0] : '' );
+		$result           = $this->unserialize( $response );
 		if ( $GLOBALS ['wp-piwik_debug'] ) {
-			self::$debug[ $id ] = array( get_headers( $full_url, 1 ), $url . '?' . $params . '&token_auth=...' );
+			self::$debug[ $id ] = [ get_headers( $full_url, 1 ), ( $this->should_use_post() ? 'POST ' : 'GET ' ) . $url . ' ' . $this->build_param_string( $params, true ) ];
 		}
 		return $result;
+	}
+
+	/**
+	 * Turn a failed or unusable response into an error message.
+	 *
+	 * @param string|false $response  response body, or false if the transfer failed.
+	 * @param string       $status    status line of the response, if known.
+	 * @return string error message, empty if the response looks usable.
+	 */
+	protected function check_response( $response, $status = '' ) {
+		$suffix = '' !== $status ? ' (' . $status . ')' : '';
+		if ( false === $response ) {
+			$error = error_get_last();
+			return ! empty( $error['message'] ) ? $error['message'] : 'Request to Matomo failed' . $suffix;
+		}
+		if ( null === json_decode( $response, true ) ) {
+			return 'Matomo did not return a valid JSON response' . $suffix;
+		}
+		return '';
 	}
 }

--- a/tests/phpunit/PhpRequestTest.php
+++ b/tests/phpunit/PhpRequestTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+use WP_Piwik\Request\Php;
+
+class Test_Php_Request extends Php {
+
+	public function build_debug_params_public( $params ) {
+		return $this->build_debug_params( $params );
+	}
+}
+
+class PhpRequestTest extends WP_Piwik_TestCase {
+
+	/**
+	 * @var Test_Php_Request
+	 */
+	private $request;
+
+	public function set_up() {
+		parent::set_up();
+		$settings                                = new \WP_Piwik_Test_Mock_Settings();
+		$settings->global_options['cache']       = false;
+		$settings->global_options['piwik_token'] = 'secret-token';
+		$settings->options['site_id']            = 7;
+		$this->request                           = new Test_Php_Request( new \WP_Piwik_Test_Mock_Plugin(), $settings );
+		$this->request->reset();
+	}
+
+	public function test_debug_params_converts_the_parameter_array_to_a_query_string() {
+		$debug = $this->request->build_debug_params_public(
+			array(
+				'method'     => 'VisitsSummary.get',
+				'idSite'     => 7,
+				'module'     => 'API',
+				'format'     => 'json',
+				'token_auth' => 'secret-token',
+			)
+		);
+
+		$this->assertSame( 'method=VisitsSummary.get&idSite=7&module=API&format=json&token_auth=...', $debug );
+	}
+
+	public function test_debug_params_mask_the_auth_token() {
+		$debug = $this->request->build_debug_params_public(
+			[
+				'method'     => 'VisitsSummary.get',
+				'token_auth' => 'secret-token',
+			]
+		);
+
+		$this->assertSame( 'method=VisitsSummary.get&token_auth=...', $debug );
+	}
+
+	public function test_debug_params_cope_with_a_missing_auth_token() {
+		$debug = $this->request->build_debug_params_public( [ 'method' => 'VisitsSummary.get' ] );
+
+		$this->assertSame( 'method=VisitsSummary.get', $debug );
+	}
+}

--- a/tests/phpunit/RequestTest.php
+++ b/tests/phpunit/RequestTest.php
@@ -32,12 +32,12 @@ class Test_Request extends Request {
 class RequestTest extends WP_Piwik_TestCase {
 
 	/**
-	 * @var \WP_Piwik_Test_Fake_Plugin
+	 * @var \WP_Piwik_Test_Mock_Plugin
 	 */
 	private $plugin;
 
 	/**
-	 * @var \WP_Piwik_Test_Fake_Settings
+	 * @var \WP_Piwik_Test_Mock_Settings
 	 */
 	private $settings;
 
@@ -48,8 +48,8 @@ class RequestTest extends WP_Piwik_TestCase {
 
 	public function set_up() {
 		parent::set_up();
-		$this->plugin                            = new \WP_Piwik_Test_Fake_Plugin();
-		$this->settings                          = new \WP_Piwik_Test_Fake_Settings();
+		$this->plugin                            = new \WP_Piwik_Test_Mock_Plugin();
+		$this->settings                          = new \WP_Piwik_Test_Mock_Settings();
 		$this->settings->global_options['cache'] = false;
 		$this->settings->options['site_id']      = 7;
 		Test_Request::$responses                 = [];

--- a/tests/phpunit/RestIntegrationTest.php
+++ b/tests/phpunit/RestIntegrationTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+use WP_Piwik\Request;
+use WP_Piwik\Request\Rest;
+
+class RestIntegrationTest extends WP_Piwik_TestCase {
+
+	/**
+	 * @var string
+	 */
+	private $runtime;
+
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! self::is_in_wp_env_environment() ) {
+			self::markTestSkipped( 'Not in wp-env environment, cannot run this test' );
+		}
+
+		$this->runtime = __DIR__ . '/rest/mock/runtime';
+		if ( ! is_dir( $this->runtime ) ) {
+			mkdir( $this->runtime, 0777, true );
+		}
+
+		// the mock runs as the web server user, the tests as the cli user
+		chmod( $this->runtime, 0777 );
+		$this->write_runtime_file( 'requests.jsonl', '' );
+		$this->set_mock_response( [ 'echo_bulk' => true ] );
+	}
+
+	private static function is_in_wp_env_environment() {
+		return defined( 'IN_WP_ENV' ) && IN_WP_ENV;
+	}
+
+	private function write_runtime_file( $name, $contents ) {
+		file_put_contents( $this->runtime . '/' . $name, $contents );
+		chmod( $this->runtime . '/' . $name, 0666 );
+	}
+
+	private function set_mock_response( array $response ) {
+		$this->write_runtime_file( 'response.json', wp_json_encode( $response ) );
+	}
+
+	private function get_captured_requests() {
+		$raw = file_get_contents( $this->runtime . '/requests.jsonl' );
+		if ( '' === trim( (string) $raw ) ) {
+			return [];
+		}
+		$requests = [];
+		foreach ( explode( "\n", trim( $raw ) ) as $line ) {
+			if ( '' !== $line ) {
+				$requests[] = json_decode( $line, true );
+			}
+		}
+		return $requests;
+	}
+
+	/**
+	 * @param bool $trailing_slash true to add a trailing slash, false if otherwise.
+	 *
+	 *                             A URL without the trailing slash makes the web
+	 *                             server answer with a 301 to URL with a slash.
+	 */
+	private function mock_url( $trailing_slash = true ) {
+		$host         = getenv( 'WP_MATOMO_TEST_HTTP_HOST' ) ? getenv( 'WP_MATOMO_TEST_HTTP_HOST' ) : 'tests-wordpress';
+		$plugins_path = wp_parse_url( plugins_url(), PHP_URL_PATH );
+		$plugin_dir   = basename( dirname( __DIR__, 2 ) );
+
+		return 'http://' . $host . rtrim( $plugins_path, '/' ) . '/' . $plugin_dir
+			. '/tests/phpunit/rest/mock' . ( $trailing_slash ? '/' : '' );
+	}
+
+	private function perform_bulk_request( $url, $connection, $method ) {
+		$settings = $this->create_settings(
+			[
+				'piwik_mode'         => 'http',
+				'piwik_url'          => $url,
+				'piwik_token'        => 'secret-token',
+				'http_connection'    => $connection,
+				'http_method'        => $method,
+				'cache'              => false,
+				'connection_timeout' => 15,
+			],
+			[ 'site_id' => 1 ]
+		);
+
+		$request = new Rest( new \WP_Piwik_Test_Mock_Plugin(), $settings );
+		$request->reset();
+		$id = Request::register(
+			'VisitsSummary.get',
+			[
+				'period' => 'day',
+				'date'   => '2015-01-01',
+			]
+		);
+
+		return [ $request->perform( $id ), Request::get_last_error() ];
+	}
+
+	public function get_transport_providers_to_test() {
+		return [
+			'curl, POST'  => [ 'curl', 'post', 'POST' ],
+			'curl, GET'   => [ 'curl', 'get', 'GET' ],
+			'fopen, POST' => [ 'fopen', 'post', 'POST' ],
+			'fopen, GET'  => [ 'fopen', 'get', 'GET' ],
+		];
+	}
+
+	/**
+	 * @dataProvider get_transport_providers_to_test
+	 */
+	public function test_bulk_request_reaches_matomo_and_returns_results( $connection, $method, $expected_http_method ) {
+		list( $result, $error ) = $this->perform_bulk_request( $this->mock_url(), $connection, $method );
+
+		$this->assertSame( [ 'nb_visits' => 1 ], $result );
+		$this->assertSame( '', $error );
+
+		$requests = $this->get_captured_requests();
+		$this->assertCount( 1, $requests );
+		$this->assertSame( $expected_http_method, $requests[0]['method'] );
+
+		$sent = 'POST' === $expected_http_method ? $requests[0]['post'] : $requests[0]['get'];
+		$this->assertSame( 'API.getBulkRequest', $sent['method'] );
+		$this->assertSame( 'secret-token', $sent['token_auth'] );
+		$this->assertSame(
+			[ 'method=VisitsSummary.get&idSite=1&period=day&date=2015-01-01' ],
+			$sent['urls']
+		);
+	}
+
+	/**
+	 * POST keeps the sub request URLs and the auth token out of the query string.
+	 *
+	 * @dataProvider get_transport_providers_to_test
+	 */
+	public function test_post_sends_nothing_in_the_query_string( $connection, $method, $expected_http_method ) {
+		$this->perform_bulk_request( $this->mock_url(), $connection, $method );
+
+		$requests = $this->get_captured_requests();
+		if ( 'POST' === $expected_http_method ) {
+			$this->assertSame( '', $requests[0]['query'] );
+			$this->assertStringNotContainsString( 'secret-token', $requests[0]['uri'] );
+		} else {
+			$this->assertStringContainsString( 'token_auth=secret-token', urldecode( $requests[0]['query'] ) );
+		}
+	}
+
+	/**
+	 * Neither transport replays a bulk request against the location a redirect
+	 * points at, so the 3xx body arrives instead and decodes to nothing. That used
+	 * to leave the stats screens empty without any explanation.
+	 *
+	 * @dataProvider get_tests_for_redirecting_transport_provider
+	 */
+	public function test_redirecting_matomo_url_is_reported_instead_of_failing_silently( $connection ) {
+		list( $result, $error ) = $this->perform_bulk_request( $this->mock_url( false ), $connection, 'post' );
+
+		$this->assertFalse( $result );
+		$this->assertStringContainsString( 'valid JSON', $error );
+		$this->assertStringContainsString( '301', $error );
+	}
+
+	public function get_tests_for_redirecting_transport_provider() {
+		return [
+			'curl'  => [ 'curl' ],
+			'fopen' => [ 'fopen' ],
+		];
+	}
+
+	/**
+	 * @dataProvider get_tests_for_redirecting_transport_provider
+	 */
+	public function test_a_non_json_response_is_reported( $connection ) {
+		$this->set_mock_response(
+			[
+				'headers' => [ 'Content-Type' => 'text/html' ],
+				'body'    => '<!DOCTYPE html><html><body>Matomo</body></html>',
+			]
+		);
+
+		list( $result, $error ) = $this->perform_bulk_request( $this->mock_url(), $connection, 'post' );
+
+		$this->assertFalse( $result );
+		$this->assertStringContainsString( 'valid JSON', $error );
+	}
+
+	/**
+	 * @dataProvider get_tests_for_redirecting_transport_provider
+	 */
+	public function test_a_server_error_is_reported( $connection ) {
+		$this->set_mock_response(
+			[
+				'status'  => 500,
+				'headers' => [ 'Content-Type' => 'text/html' ],
+				'body'    => 'Internal Server Error',
+			]
+		);
+
+		list( $result, $error ) = $this->perform_bulk_request( $this->mock_url(), $connection, 'post' );
+
+		$this->assertFalse( $result );
+		// curl hands the error page to check_response(), while the fopen stream wrapper refuses
+		// to open the stream at all, so the error message wording differs between the transports
+		$this->assertNotSame( '', $error );
+		$this->assertStringContainsString( '500', $error );
+	}
+}

--- a/tests/phpunit/RestTest.php
+++ b/tests/phpunit/RestTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+use WP_Piwik\Request;
+use WP_Piwik\Request\Rest;
+
+class Test_Rest extends Rest {
+
+	public function build_bulk_params_public() {
+		return $this->build_bulk_params();
+	}
+
+	public function build_param_string_public( $params, $mask_token = false ) {
+		return $this->build_param_string( $params, $mask_token );
+	}
+
+	public function use_post_public() {
+		return $this->should_use_post();
+	}
+
+	public function check_response_public( $response, $status = '' ) {
+		return $this->check_response( $response, $status );
+	}
+
+	public static function set_result( $id, $result ) {
+		self::$results[ $id ] = $result;
+	}
+}
+
+class RestTest extends WP_Piwik_TestCase {
+
+	/**
+	 * @var \WP_Piwik_Test_Mock_Plugin
+	 */
+	private $plugin;
+
+	/**
+	 * @var \WP_Piwik_Test_Mock_Settings
+	 */
+	private $settings;
+
+	/**
+	 * @var Test_Rest
+	 */
+	private $request;
+
+	public function set_up() {
+		parent::set_up();
+		$this->plugin                                  = new \WP_Piwik_Test_Mock_Plugin();
+		$this->settings                                = new \WP_Piwik_Test_Mock_Settings();
+		$this->settings->global_options['cache']       = false;
+		$this->settings->global_options['piwik_token'] = 'secret-token';
+		$this->settings->options['site_id']            = 7;
+		$this->request                                 = new Test_Rest( $this->plugin, $this->settings );
+		$this->request->reset();
+	}
+
+	private function register_visits_summary( $date = '2015-01-01' ) {
+		return Request::register(
+			'VisitsSummary.get',
+			[
+				'period' => 'day',
+				'date'   => $date,
+			]
+		);
+	}
+
+	public function test_bulk_params_address_the_bulk_endpoint() {
+		list( $params ) = $this->request->build_bulk_params_public();
+
+		$this->assertSame( 'API', $params['module'] );
+		$this->assertSame( 'API.getBulkRequest', $params['method'] );
+		$this->assertSame( 'json', $params['format'] );
+	}
+
+	public function test_bulk_params_collect_pending_requests_as_an_urls_array() {
+		$this->register_visits_summary( '2015-01-01' );
+		$this->register_visits_summary( '2015-01-02' );
+
+		list( $params, $map ) = $this->request->build_bulk_params_public();
+
+		$this->assertSame(
+			[
+				'method=VisitsSummary.get&idSite=7&period=day&date=2015-01-01',
+				'method=VisitsSummary.get&idSite=7&period=day&date=2015-01-02',
+			],
+			$params['urls']
+		);
+		$this->assertSame(
+			[
+				'method=VisitsSummary.get&period=day&date=2015-01-01',
+				'method=VisitsSummary.get&period=day&date=2015-01-02',
+			],
+			array_values( $map )
+		);
+	}
+
+	public function test_bulk_params_add_a_numeric_filter_limit() {
+		$this->settings->global_options['filter_limit'] = 500;
+
+		list( $params ) = $this->request->build_bulk_params_public();
+
+		$this->assertSame( 500, $params['filter_limit'] );
+	}
+
+	public function test_bulk_params_ignore_an_empty_filter_limit() {
+		$this->settings->global_options['filter_limit'] = '';
+
+		list( $params ) = $this->request->build_bulk_params_public();
+
+		$this->assertArrayNotHasKey( 'filter_limit', $params );
+	}
+
+	public function test_request_body_carries_every_parameter_so_nothing_is_left_for_a_query_string() {
+		$this->register_visits_summary();
+
+		list( $params ) = $this->request->build_bulk_params_public();
+		$body           = $this->request->build_param_string_public( $params );
+
+		$decoded = [];
+		parse_str( $body, $decoded );
+
+		$this->assertSame(
+			[
+				'module'     => 'API',
+				'method'     => 'API.getBulkRequest',
+				'format'     => 'json',
+				'urls'       => [ 'method=VisitsSummary.get&idSite=7&period=day&date=2015-01-01' ],
+				'token_auth' => 'secret-token',
+			],
+			$decoded
+		);
+	}
+
+	public function test_request_body_keeps_sub_request_query_strings_parseable() {
+		$this->register_visits_summary();
+
+		list( $params ) = $this->request->build_bulk_params_public();
+		$body           = $this->request->build_param_string_public( $params );
+
+		$decoded = [];
+		parse_str( $body, $decoded );
+
+		// this is how Matomo's API.getBulkRequest reads each sub request
+		$sub_request = [];
+		parse_str( $decoded['urls'][0], $sub_request );
+
+		$this->assertSame(
+			[
+				'method' => 'VisitsSummary.get',
+				'idSite' => '7',
+				'period' => 'day',
+				'date'   => '2015-01-01',
+			],
+			$sub_request
+		);
+	}
+
+	public function test_request_body_encodes_the_url_separators() {
+		$this->register_visits_summary();
+
+		list( $params ) = $this->request->build_bulk_params_public();
+		$body           = $this->request->build_param_string_public( $params );
+
+		$this->assertSame( 'module=API&method=API.getBulkRequest&format=json&urls%5B0%5D=method%3DVisitsSummary.get%26idSite%3D7%26period%3Dday%26date%3D2015-01-01&token_auth=secret-token', $body );
+	}
+
+	public function test_request_body_can_mask_the_auth_token_for_debug_output() {
+		list( $params ) = $this->request->build_bulk_params_public();
+
+		$body = $this->request->build_param_string_public( $params, true );
+
+		$this->assertStringNotContainsString( 'secret-token', $body );
+		$this->assertSame( 'module=API&method=API.getBulkRequest&format=json&token_auth=...', $body );
+	}
+
+	public function test_post_is_used_when_no_http_method_is_configured() {
+		$this->assertTrue( $this->request->use_post_public() );
+	}
+
+	public function test_post_is_used_when_configured() {
+		$this->settings->global_options['http_method'] = 'post';
+
+		$this->assertTrue( $this->request->use_post_public() );
+	}
+
+	public function test_get_is_used_when_explicitly_configured() {
+		$this->settings->global_options['http_method'] = 'get';
+
+		$this->assertFalse( $this->request->use_post_public() );
+	}
+
+	public function test_post_is_used_for_an_unrecognised_http_method() {
+		$this->settings->global_options['http_method'] = 'whatever';
+
+		$this->assertTrue( $this->request->use_post_public() );
+	}
+
+	public function test_check_response_accepts_a_json_document() {
+		$this->assertSame( '', $this->request->check_response_public( '[{"nb_visits":10}]' ) );
+	}
+
+	public function test_check_response_reports_a_failed_transfer() {
+		$this->assertNotSame( '', $this->request->check_response_public( false ) );
+	}
+
+	public function test_check_response_reports_a_non_json_body() {
+		// what Matomo answers when a redirect turned the POST into a bodyless GET
+		$error = $this->request->check_response_public(
+			'<!DOCTYPE html><html><body>Matomo</body></html>',
+			'HTTP/1.1 200 OK'
+		);
+
+		$this->assertStringContainsString( 'valid JSON', $error );
+		$this->assertStringContainsString( 'HTTP/1.1 200 OK', $error );
+	}
+
+	/**
+	 * @dataProvider get_redirect_bodies_for_test
+	 */
+	public function test_check_response_reports_a_redirect_body( $body, $status ) {
+		$error = $this->request->check_response_public( $body, $status );
+
+		$this->assertStringContainsString( 'valid JSON', $error );
+		$this->assertStringContainsString( $status, $error );
+	}
+
+	public function get_redirect_bodies_for_test() {
+		return [
+			'empty 301 body, fopen status' => [ '', 'HTTP/1.1 301 Moved Permanently' ],
+			'empty 302 body, curl status'  => [ '', 'HTTP 302' ],
+			'apache 301 landing page'      => [
+				'<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"><html><head>'
+				. '<title>301 Moved Permanently</title></head><body>'
+				. '<h1>Moved Permanently</h1><p>The document has moved '
+				. '<a href="https://matomo.example.org/">here</a>.</p></body></html>',
+				'HTTP/1.1 301 Moved Permanently',
+			],
+			'nginx 302 landing page'       => [
+				'<html><head><title>302 Found</title></head><body>'
+				. '<center><h1>302 Found</h1></center><hr><center>nginx</center></body></html>',
+				'HTTP 302',
+			],
+			'307 with no body at all'      => [ '', 'HTTP/1.1 307 Temporary Redirect' ],
+		];
+	}
+
+	public function test_check_response_reports_an_empty_body() {
+		$this->assertStringContainsString( 'valid JSON', $this->request->check_response_public( '', 'HTTP 200' ) );
+	}
+
+	public function test_check_response_omits_the_status_when_it_is_unknown() {
+		$error = $this->request->check_response_public( 'not json' );
+
+		$this->assertStringContainsString( 'valid JSON', $error );
+		$this->assertStringNotContainsString( '(', $error );
+	}
+
+	public function test_bulk_params_skip_requests_that_already_have_a_result() {
+		$first = $this->register_visits_summary( '2015-01-01' );
+		$this->register_visits_summary( '2015-01-02' );
+
+		Test_Rest::set_result( $first, [ 'nb_visits' => 10 ] );
+
+		list( $params, $map ) = $this->request->build_bulk_params_public();
+
+		$this->assertSame(
+			[ 'method=VisitsSummary.get&idSite=7&period=day&date=2015-01-02' ],
+			$params['urls']
+		);
+		$this->assertSame( [ 'method=VisitsSummary.get&period=day&date=2015-01-02' ], array_values( $map ) );
+	}
+}

--- a/tests/phpunit/SettingsTest.php
+++ b/tests/phpunit/SettingsTest.php
@@ -186,7 +186,7 @@ class SettingsTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_apply_changes_requests_site_id_when_auto_config_is_enabled() {
-		$plugin                = new \WP_Piwik_Test_Fake_Plugin();
+		$plugin                = new \WP_Piwik_Test_Mock_Plugin();
 		$plugin->piwik_site_id = 42;
 		$settings              = new Settings( $plugin );
 
@@ -216,7 +216,7 @@ class SettingsTest extends WP_Piwik_TestCase {
 		update_site_option( 'wp-piwik_global-piwik_url', 'https://network.example.org/' );
 		update_option( 'wp-piwik_global-piwik_url', 'https://single.example.org/' );
 
-		$settings = new Settings( new \WP_Piwik_Test_Fake_Plugin() );
+		$settings = new Settings( new \WP_Piwik_Test_Mock_Plugin() );
 
 		$this->assertSame( 'https://network.example.org/', $settings->get_global_option( 'piwik_url' ) );
 	}

--- a/tests/phpunit/TrackingCodeTest.php
+++ b/tests/phpunit/TrackingCodeTest.php
@@ -132,7 +132,7 @@ class TrackingCodeTest extends WP_Piwik_TestCase {
 
 	private function create_tracking_code( $plugin = null ) {
 		if ( null === $plugin ) {
-			$plugin = new \WP_Piwik_Test_Fake_Plugin();
+			$plugin = new \WP_Piwik_Test_Mock_Plugin();
 		}
 		if ( ! isset( $plugin->options['tracking_code'] ) ) {
 			$plugin->options['tracking_code'] = $this->get_sample_code();
@@ -147,7 +147,7 @@ class TrackingCodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_constructor_refreshes_outdated_tracking_code() {
-		$plugin                        = new \WP_Piwik_Test_Fake_Plugin();
+		$plugin                        = new \WP_Piwik_Test_Mock_Plugin();
 		$plugin->current_tracking_code = false;
 
 		$this->create_tracking_code( $plugin );
@@ -156,7 +156,7 @@ class TrackingCodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_constructor_refreshes_tracking_code_containing_an_error() {
-		$plugin                           = new \WP_Piwik_Test_Fake_Plugin();
+		$plugin                           = new \WP_Piwik_Test_Mock_Plugin();
 		$plugin->options['tracking_code'] = '{"result":"error","message":"no access"}';
 
 		$this->create_tracking_code( $plugin );
@@ -165,7 +165,7 @@ class TrackingCodeTest extends WP_Piwik_TestCase {
 	}
 
 	public function test_constructor_uses_site_option_in_network_mode_with_manual_tracking() {
-		$plugin                               = new \WP_Piwik_Test_Fake_Plugin();
+		$plugin                               = new \WP_Piwik_Test_Mock_Plugin();
 		$plugin->network_mode                 = true;
 		$plugin->global_options['track_mode'] = 'manually';
 		$plugin->options['tracking_code']     = 'blog level code';
@@ -209,7 +209,7 @@ class TrackingCodeTest extends WP_Piwik_TestCase {
 		$user_id = self::factory()->user->create( [ 'user_email' => 'user@example.org' ] );
 		wp_set_current_user( $user_id );
 
-		$plugin                                  = new \WP_Piwik_Test_Fake_Plugin();
+		$plugin                                  = new \WP_Piwik_Test_Mock_Plugin();
 		$plugin->global_options['track_user_id'] = 'email';
 
 		$tracking_code                  = $this->create_tracking_code( $plugin );
@@ -223,7 +223,7 @@ class TrackingCodeTest extends WP_Piwik_TestCase {
 	public function test_get_tracking_code_skips_user_id_tracking_for_anonymous_visitors() {
 		wp_set_current_user( 0 );
 
-		$plugin                                  = new \WP_Piwik_Test_Fake_Plugin();
+		$plugin                                  = new \WP_Piwik_Test_Mock_Plugin();
 		$plugin->global_options['track_user_id'] = 'email';
 
 		$tracking_code                  = $this->create_tracking_code( $plugin );

--- a/tests/phpunit/WP_Piwik_TestCase.php
+++ b/tests/phpunit/WP_Piwik_TestCase.php
@@ -96,6 +96,6 @@ abstract class WP_Piwik_TestCase extends \WP_UnitTestCase {
 		foreach ( $options as $key => $value ) {
 			update_option( 'wp-piwik-' . $key, $value );
 		}
-		return new \WP_Piwik\Settings( new \WP_Piwik_Test_Fake_Plugin() );
+		return new \WP_Piwik\Settings( new \WP_Piwik_Test_Mock_Plugin() );
 	}
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -39,6 +39,6 @@ tests_add_filter(
 // boot the WordPress test environment.
 require $_tests_dir . '/includes/bootstrap.php';
 
-require_once __DIR__ . '/fake/Plugin.php';
-require_once __DIR__ . '/fake/Settings.php';
+require_once __DIR__ . '/mock/Plugin.php';
+require_once __DIR__ . '/mock/Settings.php';
 require_once __DIR__ . '/WP_Piwik_TestCase.php';

--- a/tests/phpunit/mock/Plugin.php
+++ b/tests/phpunit/mock/Plugin.php
@@ -1,7 +1,7 @@
 <?php
 // phpcs:ignoreFile -- mock types, not WordPress plugin code.
 
-class WP_Piwik_Test_Fake_Plugin {
+class WP_Piwik_Test_Mock_Plugin {
 
 	public $options               = [];
 	public $global_options        = [];

--- a/tests/phpunit/mock/Settings.php
+++ b/tests/phpunit/mock/Settings.php
@@ -1,7 +1,7 @@
 <?php
 // phpcs:ignoreFile -- mock types, not WordPress plugin code.
 
-class WP_Piwik_Test_Fake_Settings {
+class WP_Piwik_Test_Mock_Settings {
 
 	public $global_options = [];
 	public $options        = [];

--- a/tests/phpunit/proxy/Proxy_Test_Harness.php
+++ b/tests/phpunit/proxy/Proxy_Test_Harness.php
@@ -170,13 +170,19 @@ class Proxy_Test_Harness {
 		$raw = curl_exec( $ch );
 		if ( false === $raw ) {
 			$error = curl_error( $ch );
-			curl_close( $ch );
+			if ( version_compare( PHP_VERSION, '8', '<' ) ) {
+				// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated
+				curl_close( $ch );
+			}
 			throw new \Exception( 'Request to the proxy failed: ' . $error );
 		}
 
 		$status      = (int) curl_getinfo( $ch, CURLINFO_HTTP_CODE );
 		$header_size = (int) curl_getinfo( $ch, CURLINFO_HEADER_SIZE );
-		curl_close( $ch );
+		if ( version_compare( PHP_VERSION, '8', '<' ) ) {
+			// phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated
+			curl_close( $ch );
+		}
 
 		$raw_headers = substr( $raw, 0, $header_size );
 		$body_out    = substr( $raw, $header_size );

--- a/tests/phpunit/rest/mock/index.php
+++ b/tests/phpunit/rest/mock/index.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Mock Matomo API endpoint for the Rest request integration tests.
+ * Records every request it receives and answers according to runtime/response.json.
+ *
+ * @package wp-piwik
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ * phpcs:disable WordPress.Security.ValidatedSanitizedInput
+ * phpcs:disable WordPress.Security.NonceVerification.Missing
+ */
+
+$runtime = __DIR__ . '/runtime';
+
+$record = [
+	'method' => isset( $_SERVER['REQUEST_METHOD'] ) ? $_SERVER['REQUEST_METHOD'] : '',
+	'uri'    => isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '',
+	'query'  => isset( $_SERVER['QUERY_STRING'] ) ? $_SERVER['QUERY_STRING'] : '',
+	'get'    => $_GET,
+	'post'   => $_POST,
+	'body'   => file_get_contents( 'php://input' ),
+];
+
+// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+@file_put_contents( $runtime . '/requests.jsonl', json_encode( $record ) . "\n", FILE_APPEND | LOCK_EX );
+
+$response = [
+	'status'  => 200,
+	'headers' => [ 'Content-Type' => 'application/json' ],
+	'body'    => '[]',
+];
+
+$response_file = $runtime . '/response.json';
+if ( is_file( $response_file ) ) {
+	$decoded = json_decode( file_get_contents( $response_file ), true );
+	if ( is_array( $decoded ) ) {
+		$response = array_merge( $response, $decoded );
+	}
+}
+
+// answer a bulk request with one result per submitted url
+if ( ! empty( $response['echo_bulk'] ) ) {
+	$bulk_urls = isset( $_POST['urls'] ) ? $_POST['urls'] : ( isset( $_GET['urls'] ) ? $_GET['urls'] : [] );
+	if ( empty( $bulk_urls ) ) {
+		// a request that carries no API parameters is answered by Matomo with its
+		// UI rather than with JSON, which is what the plugin ends up
+		// with when a redirect drops the request body
+		$response['headers'] = [ 'Content-Type' => 'text/html; charset=utf-8' ];
+		$response['body']    = '<!DOCTYPE html><html><head><title>Matomo</title></head><body>Sign in</body></html>';
+	} else {
+		$results = [];
+		foreach ( (array) $bulk_urls as $index => $url ) {
+			$results[] = [ 'nb_visits' => $index + 1 ];
+		}
+		$response['body'] = json_encode( $results );
+	}
+}
+
+http_response_code( (int) $response['status'] );
+
+foreach ( (array) $response['headers'] as $name => $value ) {
+	header( $name . ': ' . $value, true );
+}
+
+echo $response['body'];


### PR DESCRIPTION
### Description

Changes:
* Default to using POST requests to Matomo rather than GET. (We still allow GET requests since it may be necessary for edge cases where Matomo instances return redirects).
* Add unit + integration tests around code that makes requests to Matomo.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
