### PR TITLE
fix current value detection in show_select() caused by strict comparison

### DIFF
--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -863,7 +863,7 @@ class Settings extends \WP_Piwik\Admin {
 	 * @param boolean $hide_description $hideDescription set to false to show description initially (default: true)
 	 * @param boolean $is_global set to false if the textarea shows a site-specific option (default: true)
 	 */
-	private function show_select( $id, $name, $options = array(), $description = '', $on_change = '', $is_hidden = false, $group_name = '', $hide_description = true, $is_global = true ) {
+	public function show_select( $id, $name, $options = array(), $description = '', $on_change = '', $is_hidden = false, $group_name = '', $hide_description = true, $is_global = true ) {
 		$default = $is_global ? self::$settings->get_global_option( $id ) : self::$settings->get_option( $id );
 
 		$this->show_input_wrapper(
@@ -877,7 +877,7 @@ class Settings extends \WP_Piwik\Admin {
 				?>
 			<select name="wp-piwik[<?php echo esc_attr( $id ); ?>]" id="<?php echo esc_attr( $id ); ?>" onchange="<?php echo esc_attr( $on_change ); ?>">
 				<?php foreach ( $options as $key => $value ) : ?>
-					<option value="<?php echo esc_attr( $key ); ?>" <?php echo ( $key === $default ? ' selected="selected"' : '' ); ?> ><?php echo esc_html( $value ); ?></option>
+					<option value="<?php echo esc_attr( $key ); ?>" <?php echo ( (string) $key === (string) $default ? ' selected="selected"' : '' ); ?> ><?php echo esc_html( $value ); ?></option>
 				<?php endforeach; ?>
 			</select>
 				<?php

--- a/tests/phpunit/AdminSettingsTest.php
+++ b/tests/phpunit/AdminSettingsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WP_Piwik\Tests;
+
+use WP_Piwik\Admin\Settings as AdminSettings;
+
+class AdminSettingsTest extends WP_Piwik_TestCase {
+
+	private function render_select( $settings, $id, array $options, $is_global ) {
+		$admin = new AdminSettings( new \WP_Piwik_Test_Mock_Plugin(), $settings );
+		ob_start();
+		$admin->show_select( $id, 'Select site', $options, '', '', false, '', true, $is_global );
+		return ob_get_clean();
+	}
+
+	private function get_selected_option_values( $html ) {
+		preg_match_all( '/<option value="([^"]*)"[^>]*selected="selected"/', $html, $matches );
+		return $matches[1];
+	}
+
+	public function test_show_select_marks_the_stored_option_as_selected_for_integer_keys() {
+		// site_id stored as an integer.
+		update_option( 'wp-piwik-site_id', 2 );
+
+		// drop the options cache to simulate a fresh page load
+		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( 'wp-piwik-site_id', 'options' );
+
+		$settings = new \WP_Piwik\Settings( new \WP_Piwik_Test_Mock_Plugin() );
+		$this->assertSame( '2', $settings->get_option( 'site_id' ), 'precondition: stored site_id reads back as a string' );
+
+		// the site list is keyed by idsite, so the keys are integers.
+		$options = [
+			1 => 'website1 (http://website1.com)',
+			2 => 'website2 (http://website2.com)',
+		];
+
+		$html = $this->render_select( $settings, 'site_id', $options, false );
+
+		$this->assertSame( [ '2' ], $this->get_selected_option_values( $html ), 'the stored site must be the only selected option' );
+	}
+
+	public function test_show_select_selects_nothing_when_no_value_is_stored() {
+		$settings = $this->create_settings();
+
+		$options = [
+			1 => 'website1 (http://website1.com)',
+			2 => 'website2 (http://website2.com)',
+		];
+
+		$html = $this->render_select( $settings, 'site_id', $options, false );
+
+		// nothing stored yet, so no option should be forced selected.
+		$this->assertSame( [], $this->get_selected_option_values( $html ) );
+	}
+
+	public function test_show_select_marks_the_stored_option_as_selected_for_string_keys() {
+		$settings = $this->create_settings( [ 'default_date' => 'last_month' ] );
+
+		$options = [
+			'today'      => 'Today',
+			'yesterday'  => 'Yesterday',
+			'last_month' => 'Last month',
+		];
+
+		$html = $this->render_select( $settings, 'default_date', $options, true );
+
+		$this->assertSame( [ 'last_month' ], $this->get_selected_option_values( $html ) );
+	}
+}


### PR DESCRIPTION
### Description

See https://wordpress.org/support/topic/matomo-no-longer-retain-the-correct-site-after-1-1-version/

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
