### PR TITLE
deprecate PHP-API connection mode + stat displaying shortcodes

### DIFF
--- a/.ddev/README.md
+++ b/.ddev/README.md
@@ -91,8 +91,8 @@ web_environment:
 ```
 
 A publicly resolvable Matomo needs nothing else. A Matomo running in *another DDEV project* is not
-in DNS, so `.ddev/docker-compose.matomo-host.yaml` maps its hostname onto the Docker host, where
-ddev-router listens. Add an entry there for any additional project you want to reach:
+in DNS, so add a `.ddev/docker-compose.matomo-host.yaml` that maps its hostname onto the Docker host,
+where ddev-router listens. Add an entry there for any additional project you want to reach, for example:
 
 ```yaml
 services:

--- a/.ddev/commands/web/wp-matomo_install
+++ b/.ddev/commands/web/wp-matomo_install
@@ -102,7 +102,61 @@ install_site() {
 		--admin_password=admin \
 		--admin_email=admin@example.com \
 		--skip-email
-	wp rewrite structure '/%postname%/' --path="$path" --hard
+	# no --hard here: it delegates to write_htaccess() below instead. See there.
+	wp rewrite structure '/%postname%/' --path="$path"
+}
+
+# WordPress' own .htaccess writer, save_mod_rewrite_rules(), is a silent no-op
+# under WP-CLI. It needs $_SERVER['SERVER_SOFTWARE'] to recognise Apache and
+# $_SERVER['SCRIPT_FILENAME'] to locate the docroot, and neither exists outside a
+# web request, so it returns early -- while "wp rewrite flush --hard" still exits
+# 0. The .htaccess file is still necessary, so it's written manually here.
+write_htaccess() {
+	local path="$1" flavour="$2"
+
+	if [ -f "${path}/.htaccess" ] && [ "$FORCE" != "1" ]; then
+		echo "    .htaccess already present, leaving it alone"
+		return
+	fi
+
+	if [ "$flavour" = "multisite" ]; then
+		# the subdirectory-network rules, which wp-cli cannot generate at all
+		cat >"${path}/.htaccess" <<'HTACCESS'
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule . index.php [L]
+</IfModule>
+# END WordPress
+HTACCESS
+	else
+		cat >"${path}/.htaccess" <<'HTACCESS'
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress
+HTACCESS
+	fi
+	echo "    wrote .htaccess"
 }
 
 activate_plugin() {
@@ -122,6 +176,7 @@ if wants single; then
 	download_core "${DOCROOT}/single" "$WP_VERSION"
 	write_config "${DOCROOT}/single" "wp_"
 	install_site "${DOCROOT}/single" "${DDEV_PRIMARY_URL}" "Connect Matomo (single site)"
+	write_htaccess "${DOCROOT}/single" single
 	activate_plugin "${DOCROOT}/single" 0
 fi
 
@@ -137,6 +192,7 @@ if wants multisite; then
 		echo "    converting to a subdirectory network"
 		wp core multisite-convert --path="${DOCROOT}/multisite" --title="Connect Matomo network"
 	fi
+	write_htaccess "${DOCROOT}/multisite" multisite
 	activate_plugin "${DOCROOT}/multisite" 1
 fi
 

--- a/.ddev/docker-compose.matomo-host.yaml
+++ b/.ddev/docker-compose.matomo-host.yaml
@@ -4,4 +4,4 @@
 services:
   web:
     extra_hosts:
-      - "matomo.ddev.site:host-gateway"
+

--- a/.ddev/docker-compose.matomo-host.yaml
+++ b/.ddev/docker-compose.matomo-host.yaml
@@ -1,7 +1,0 @@
-# Lets the web container resolve another DDEV project's hostname, so the plugin
-# can talk to a Matomo that runs in its own DDEV project -- by default the one
-# in the sibling matomo repository at https://matomo.ddev.site.
-services:
-  web:
-    extra_hosts:
-

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -10,6 +10,20 @@ use WP_Piwik\Widget\Post;
  */
 class WP_Piwik {
 
+	/**
+	 * Option holding the deprecated shortcode modules this site has rendered
+	 *
+	 * @see record_deprecated_shortcode_use()
+	 */
+	const DEPRECATED_SHORTCODES_OPTION = 'wp-piwik-deprecated_shortcodes';
+
+	/**
+	 * Query argument, and nonce action, of the deprecated shortcode notice's dismiss link
+	 *
+	 * @see on_deprecated_shortcode_notice_dismissed()
+	 */
+	const DISMISS_SHORTCODE_NOTICE_ARG = 'wp-piwik-dismiss-shortcode-notice';
+
 	private static $revision_id = 2023092201;
 	private static $version     = '1.1.11';
 	private static $blog_id;
@@ -158,6 +172,20 @@ class WP_Piwik {
 				array(
 					$this,
 					'show_php_mode_deprecation_notice_if_in_use',
+				)
+			);
+			add_action(
+				$this->is_network_mode() ? 'network_admin_notices' : 'admin_notices',
+				array(
+					$this,
+					'show_deprecated_shortcode_notice_if_in_use',
+				)
+			);
+			add_action(
+				'admin_init',
+				array(
+					$this,
+					'on_deprecated_shortcode_notice_dismissed',
 				)
 			);
 			if ( $this->is_dashboard_active() ) {
@@ -338,6 +366,7 @@ class WP_Piwik {
 			exit();
 		}
 		self::delete_word_press_option( 'wp-piwik-notices' );
+		self::delete_word_press_option( self::DEPRECATED_SHORTCODES_OPTION );
 		self::$settings->reset_settings();
 	}
 
@@ -440,6 +469,185 @@ class WP_Piwik {
 			self::get_php_mode_deprecation_message(),
 			esc_attr( $this->get_settings_url() ),
 			esc_html__( 'Open the WP-Matomo settings', 'wp-piwik' )
+		);
+	}
+
+	/**
+	 * Record that a deprecated shortcode module was rendered on this site.
+	 *
+	 * Nothing about a site says where its shortcodes are: they can sit in a post, a
+	 * reusable block, a sidebar widget or a theme template. So the admin notice is driven
+	 * by what actually renders.
+	 *
+	 * @param string $module deprecated shortcode module that was rendered
+	 */
+	public function record_deprecated_shortcode_use( $module ) {
+		$record          = $this->get_deprecated_shortcode_record();
+		$dismissed_until = $record['dismissed_until'];
+		$last_seen       = isset( $record['modules'][ $module ] ) ? $record['modules'][ $module ] : 0;
+
+		if ( $last_seen > $dismissed_until ) {
+			return; // record already showing
+		}
+
+		if ( time() <= $dismissed_until ) {
+			return; // notice is dismissed, no need to record
+		}
+
+		// the dismissal has run out and a deprecated shortcode rendered again, so this
+		// render is what brings the notice back
+		$record['modules'][ $module ] = time();
+		$this->update_word_press_option( self::DEPRECATED_SHORTCODES_OPTION, $record );
+	}
+
+	/**
+	 * Get the deprecated shortcode modules whose use this site should be warned about.
+	 *
+	 * A module drops off the list while the notice is dismissed, and stays off unless it
+	 * renders again once the dismissal has run out.
+	 *
+	 * @return string[] module names, in the order \WP_Piwik\Shortcode declares them
+	 */
+	public function get_recorded_deprecated_shortcodes() {
+		$record  = $this->get_deprecated_shortcode_record();
+		$modules = array();
+		foreach ( $record['modules'] as $module => $last_seen ) {
+			if ( $last_seen > $record['dismissed_until'] ) {
+				$modules[] = $module;
+			}
+		}
+		return $modules;
+	}
+
+	/**
+	 * Keep the deprecated shortcode notice away for a week.
+	 *
+	 * It comes back when a deprecated shortcode renders again after that, so a site that
+	 * removed its shortcodes in the meantime is not warned a second time.
+	 *
+	 * @see record_deprecated_shortcode_use()
+	 */
+	public function dismiss_deprecated_shortcode_notice() {
+		$record                    = $this->get_deprecated_shortcode_record();
+		$record['dismissed_until'] = time() + WEEK_IN_SECONDS;
+		$this->update_word_press_option( self::DEPRECATED_SHORTCODES_OPTION, $record );
+	}
+
+	/**
+	 * Handle the dismiss link of the deprecated shortcode notice
+	 */
+	public function on_deprecated_shortcode_notice_dismissed() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET[ self::DISMISS_SHORTCODE_NOTICE_ARG ] ) ) {
+			return;
+		}
+
+		check_admin_referer( self::DISMISS_SHORTCODE_NOTICE_ARG );
+
+		if ( current_user_can( $this->is_network_mode() ? 'manage_sites' : 'activate_plugins' ) ) {
+			$this->dismiss_deprecated_shortcode_notice();
+		}
+
+		// reload the current page without the dismissal query param
+		if ( wp_safe_redirect( remove_query_arg( array( self::DISMISS_SHORTCODE_NOTICE_ARG, '_wpnonce' ) ) ) ) {
+			exit;
+		}
+	}
+
+	/**
+	 * Read what this site has recorded about the deprecated shortcodes
+	 *
+	 * @return array modules (module name => timestamp of the render that armed the notice)
+	 *          and dismissed_until (timestamp, 0 if the notice was never dismissed)
+	 */
+	private function get_deprecated_shortcode_record() {
+		$stored          = $this->get_word_press_option( self::DEPRECATED_SHORTCODES_OPTION, array() );
+		$stored          = is_array( $stored ) ? $stored : array();
+		$stored_modules  = isset( $stored['modules'] ) && is_array( $stored['modules'] ) ? $stored['modules'] : array();
+		$dismissed_until = isset( $stored['dismissed_until'] ) && is_numeric( $stored['dismissed_until'] ) ? (int) $stored['dismissed_until'] : 0;
+
+		// make sure the module entries in the option are valid modules
+		$modules = array();
+		foreach ( \WP_Piwik\Shortcode::get_deprecated_modules() as $module ) {
+			if ( isset( $stored_modules[ $module ] ) && is_numeric( $stored_modules[ $module ] ) ) {
+				$modules[ $module ] = (int) $stored_modules[ $module ];
+			}
+		}
+
+		return array(
+			'modules'         => $modules,
+			'dismissed_until' => $dismissed_until,
+		);
+	}
+
+	/**
+	 * @param string[] $modules deprecated shortcode modules the site has rendered
+	 * @return string message HTML, already escaped
+	 */
+	public static function get_deprecated_shortcode_message( $modules ) {
+		$tags = array();
+		foreach ( $modules as $module ) {
+			$tags[] = self::get_shortcode_example( $module );
+		}
+
+		return '<strong>'
+			. esc_html__( 'The statistics shortcodes are deprecated and will be removed by November 2026 at the latest.', 'wp-piwik' )
+			. '</strong><br/><br/>'
+			. sprintf(
+				/* translators: %s: comma separated list of shortcodes, e.g. [wp-piwik module="overview"] */
+				esc_html__( 'This site renders %s, which report Matomo data into a page using the auth token WP-Matomo stores for the whole site. They will be removed in the next major release of WP-Matomo.', 'wp-piwik' ),
+				implode( ', ', $tags )
+			)
+			. ' '
+			. sprintf(
+				/* translators: %1$s: opening link tag to the Matomo Widgetize documentation, %2$s: closing link tag */
+				esc_html__( 'Matomo\'s %1$sWidgetize%2$s feature is the supported replacement: it serves the same reports from Matomo itself. Create a dedicated read-only auth token in Matomo to use with it, so that an embedded report cannot reach anything else.', 'wp-piwik' ),
+				'<a href="https://matomo.org/docs/embed-piwik-report/" target="_blank" rel="noreferrer noopener">',
+				'</a>'
+			)
+			. '<br/><br/>'
+			. sprintf(
+				/* translators: %s: the opt-out shortcode, e.g. [wp-piwik module="opt-out"] */
+				esc_html__( 'The %s shortcode is not deprecated and will continue to function.', 'wp-piwik' ),
+				self::get_shortcode_example( 'opt-out' )
+			)
+			. '<br/><br/>';
+	}
+
+	/**
+	 * Render a shortcode for a message to show it in
+	 *
+	 * @param string $module module the example uses
+	 * @return string shortcode HTML, already escaped
+	 */
+	private static function get_shortcode_example( $module ) {
+		return '<code>' . esc_html( '[' . \WP_Piwik\Shortcode::TAG . ' module="' . $module . '"]' ) . '</code>';
+	}
+
+	/**
+	 * Show a deprecation notice if this site renders the deprecated statistics shortcodes
+	 *
+	 * @see get_deprecated_shortcode_message()
+	 */
+	public function show_deprecated_shortcode_notice_if_in_use() {
+		$modules = $this->get_recorded_deprecated_shortcodes();
+		if ( empty( $modules ) ) {
+			return;
+		}
+
+		// only show to users who can act on it
+		if ( ! current_user_can( $this->is_network_mode() ? 'manage_sites' : 'activate_plugins' ) ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-warning"><p>%s</p><p><a href="%s">%s</a> | <a href="%s" target="_blank" rel="noreferrer noopener">%s</a></p></div>',
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by get_deprecated_shortcode_message()
+			self::get_deprecated_shortcode_message( $modules ),
+			esc_url( wp_nonce_url( add_query_arg( self::DISMISS_SHORTCODE_NOTICE_ARG, '1' ), self::DISMISS_SHORTCODE_NOTICE_ARG ) ),
+			esc_html__( 'Dismiss this notice for a week', 'wp-piwik' ),
+			esc_attr( 'https://matomo.org/faq/reports/embed-a-matomo-report-in-a-html-page/' ),
+			esc_html__( 'Learn how to embed a Matomo report', 'wp-piwik' )
 		);
 	}
 

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -467,7 +467,7 @@ class WP_Piwik {
 			'<div class="notice notice-warning"><p>%s <br/><br/><a href="%s">%s</a></p></div>',
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by get_php_mode_deprecation_message()
 			self::get_php_mode_deprecation_message(),
-			esc_attr( $this->get_settings_url() ),
+			esc_url( $this->get_settings_url() ),
 			esc_html__( 'Open the WP-Matomo settings', 'wp-piwik' )
 		);
 	}
@@ -549,7 +549,7 @@ class WP_Piwik {
 		}
 
 		// reload the current page without the dismissal query param
-		if ( wp_safe_redirect( remove_query_arg( array( self::DISMISS_SHORTCODE_NOTICE_ARG, '_wpnonce' ) ) ) ) {
+		if ( wp_safe_redirect( remove_query_arg( array( self::DISMISS_SHORTCODE_NOTICE_ARG, '_wpnonce', 'clear', 'testscript' ) ) ) ) {
 			exit;
 		}
 	}
@@ -595,7 +595,7 @@ class WP_Piwik {
 			. '</strong><br/><br/>'
 			. sprintf(
 				/* translators: %s: comma separated list of shortcodes, e.g. [wp-piwik module="overview"] */
-				esc_html__( 'This site renders %s, which report Matomo data into a page using the auth token WP-Matomo stores for the whole site. They will be removed in the next major release of WP-Matomo.', 'wp-piwik' ),
+				esc_html__( 'This site renders %s, which display(s) Matomo data in a page using the auth token WP-Matomo stores for the whole site. They will be removed in the next major release of WP-Matomo.', 'wp-piwik' ),
 				implode( ', ', $tags )
 			)
 			. ' '
@@ -615,8 +615,6 @@ class WP_Piwik {
 	}
 
 	/**
-	 * Render a shortcode for a message to show it in
-	 *
 	 * @param string $module module the example uses
 	 * @return string shortcode HTML, already escaped
 	 */
@@ -624,11 +622,6 @@ class WP_Piwik {
 		return '<code>' . esc_html( '[' . \WP_Piwik\Shortcode::TAG . ' module="' . $module . '"]' ) . '</code>';
 	}
 
-	/**
-	 * Show a deprecation notice if this site renders the deprecated statistics shortcodes
-	 *
-	 * @see get_deprecated_shortcode_message()
-	 */
 	public function show_deprecated_shortcode_notice_if_in_use() {
 		$modules = $this->get_recorded_deprecated_shortcodes();
 		if ( empty( $modules ) ) {
@@ -646,7 +639,7 @@ class WP_Piwik {
 			self::get_deprecated_shortcode_message( $modules ),
 			esc_url( wp_nonce_url( add_query_arg( self::DISMISS_SHORTCODE_NOTICE_ARG, '1' ), self::DISMISS_SHORTCODE_NOTICE_ARG ) ),
 			esc_html__( 'Dismiss this notice for a week', 'wp-piwik' ),
-			esc_attr( 'https://matomo.org/faq/reports/embed-a-matomo-report-in-a-html-page/' ),
+			esc_url( 'https://matomo.org/faq/reports/embed-a-matomo-report-in-a-html-page/' ),
 			esc_html__( 'Learn how to embed a Matomo report', 'wp-piwik' )
 		);
 	}

--- a/classes/WP_Piwik.php
+++ b/classes/WP_Piwik.php
@@ -153,6 +153,13 @@ class WP_Piwik {
 					)
 				);
 			}
+			add_action(
+				$this->is_network_mode() ? 'network_admin_notices' : 'admin_notices',
+				array(
+					$this,
+					'show_php_mode_deprecation_notice_if_in_use',
+				)
+			);
 			if ( $this->is_dashboard_active() ) {
 				add_action(
 					'wp_dashboard_setup',
@@ -409,6 +416,31 @@ class WP_Piwik {
 			}
 		}
 		$this->update_word_press_option( 'wp-piwik-notices', $notices );
+	}
+
+	public static function get_php_mode_deprecation_message() {
+		return '<strong>' . esc_html__( 'The "Self-hosted (PHP API)" connection method is deprecated and will be removed by November 2026 at the latest.', 'wp-piwik' ) . '</strong><br/><br/>'
+			. esc_html__( 'It loads Matomo into WordPress instead of requesting the reports over http(s), which requires having Matomo code locally, gives the Matomo code full access to your WordPress installation and offers nothing the HTTP API does not. It will be removed in the next major release of WP-Matomo.', 'wp-piwik' ) . ' '
+			. esc_html__( 'Please switch this site to "Self-hosted (HTTP API)" and enter the URL of your Matomo instance.', 'wp-piwik' );
+	}
+
+	public function show_php_mode_deprecation_notice_if_in_use() {
+		if ( ! $this->is_php_mode() ) {
+			return;
+		}
+
+		// only show to users that can actually change the setting
+		if ( ! current_user_can( $this->is_network_mode() ? 'manage_sites' : 'activate_plugins' ) ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-warning"><p>%s <br/><br/><a href="%s">%s</a></p></div>',
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped by get_php_mode_deprecation_message()
+			self::get_php_mode_deprecation_message(),
+			esc_attr( $this->get_settings_url() ),
+			esc_html__( 'Open the WP-Matomo settings', 'wp-piwik' )
+		);
 	}
 
 	/**
@@ -937,6 +969,9 @@ class WP_Piwik {
 	/**
 	 * Check if PHP mode is chosen
 	 *
+	 * @deprecated 1.1.11 the PHP API is deprecated and will be removed in the next major
+	 *             release, see get_php_mode_deprecation_message().
+	 *
 	 * @return bool Is PHP mode chosen?
 	 */
 	public function is_php_mode() {
@@ -1035,6 +1070,10 @@ class WP_Piwik {
 
 	/**
 	 * Define Piwik constants for PHP reporting API
+	 *
+	 * @deprecated 1.1.11 the PHP API is deprecated and will be removed in the next major
+	 *             release, see get_php_mode_deprecation_message().
+	 *
 	 * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 	 */
 	public static function define_piwik_constants() {

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -126,17 +126,16 @@ class Settings extends \WP_Piwik\Admin {
 				$this->show_box( 'error', 'no', esc_html__( 'Neither cURL nor fopen are available. So WP-Matomo can not use the HTTP API and not connect to InnoCraft Cloud.', 'wp-piwik' ) . ' ' . sprintf( '<a href="%s">%s.</a>', 'https://wordpress.org/plugins/wp-piwik/faq/', esc_html__( 'More information', 'wp-piwik' ) ) );
 			}
 
-			$description = sprintf( '%s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s', esc_html__( 'You can choose between three connection methods:', 'wp-piwik' ), esc_html__( 'Self-hosted (HTTP API, default)', 'wp-piwik' ), esc_html__( 'This is the default option for a self-hosted Matomo and should work for most configurations. WP-Matomo will connect to Matomo using http(s).', 'wp-piwik' ), esc_html__( 'Self-hosted (PHP API)', 'wp-piwik' ), esc_html__( 'Choose this, if your self-hosted Matomo and WordPress are running on the same machine and you know the full server path to your Matomo instance.', 'wp-piwik' ), esc_html__( 'Cloud-hosted', 'wp-piwik' ), esc_html__( 'If you are using a cloud-hosted Matomo by InnoCraft, you can simply use this option. Be carefull to choose the option which fits to your cloud domain (matomo.cloud or innocraft.cloud).', 'wp-piwik' ) );
+			// the message is already escaped, show_box() passes its content through unescaped
+			if ( 'php' === self::$settings->get_global_option( 'piwik_mode' ) ) {
+				$this->show_box( 'notice notice-warning', 'warning', \WP_Piwik::get_php_mode_deprecation_message() );
+			}
+
+			$description = sprintf( '%s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s', esc_html__( 'You can choose between two connection methods:', 'wp-piwik' ), esc_html__( 'Self-hosted (HTTP API, default)', 'wp-piwik' ), esc_html__( 'This is the default option for a self-hosted Matomo and should work for most configurations. WP-Matomo will connect to Matomo using http(s).', 'wp-piwik' ), esc_html__( 'Cloud-hosted', 'wp-piwik' ), esc_html__( 'If you are using a cloud-hosted Matomo by InnoCraft, you can simply use this option. Be careful to choose the option that matches your cloud domain (matomo.cloud or innocraft.cloud).', 'wp-piwik' ) );
 			$this->show_select(
 				'piwik_mode',
 				__( 'Matomo Mode', 'wp-piwik' ),
-				array(
-					'disabled'     => __( 'Disabled (WP-Matomo will not connect to Matomo)', 'wp-piwik' ),
-					'http'         => __( 'Self-hosted (HTTP API, default)', 'wp-piwik' ),
-					'php'          => __( 'Self-hosted (PHP API)', 'wp-piwik' ),
-					'cloud-matomo' => __( 'Cloud-hosted (Innocraft Cloud, *.matomo.cloud)', 'wp-piwik' ),
-					'cloud'        => __( 'Cloud-hosted (InnoCraft Cloud, *.innocraft.cloud)', 'wp-piwik' ),
-				),
+				$this->get_matomo_mode_options(),
 				$description,
 				'jQuery(\'tr.wp-piwik-mode-option\').addClass(\'hidden\'); jQuery(\'.wp-piwik-mode-option-\' + jQuery(\'#piwik_mode\').val()).removeClass(\'hidden\');',
 				false,
@@ -145,7 +144,9 @@ class Settings extends \WP_Piwik\Admin {
 			);
 
 			$this->show_input( 'piwik_url', __( 'Matomo URL', 'wp-piwik' ), __( 'Enter your Matomo URL. This is the same URL you use to access your Matomo instance, e.g. http://www.example.com/matomo/.', 'wp-piwik' ), 'http' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'http', self::$wp_piwik->is_configured(), true );
-			$this->show_input( 'piwik_path', __( 'Matomo path', 'wp-piwik' ), __( 'Enter the file path to your Matomo instance, e.g. /var/www/matomo/.', 'wp-piwik' ), 'php' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'php', self::$wp_piwik->is_configured(), true );
+			if ( 'php' === self::$settings->get_global_option( 'piwik_mode' ) ) {
+				$this->show_input( 'piwik_path', __( 'Matomo path (deprecated)', 'wp-piwik' ), __( 'Enter the file path to your Matomo instance, e.g. /var/www/matomo/. Only used by the deprecated "Self-hosted (PHP API)" connection method.', 'wp-piwik' ), 'php' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'php', self::$wp_piwik->is_configured(), true );
+			}
 			$this->show_input( 'piwik_user', __( 'Innocraft subdomain', 'wp-piwik' ), __( 'Enter your InnoCraft Cloud subdomain. It is also part of your URL: https://SUBDOMAIN.innocraft.cloud.', 'wp-piwik' ), 'cloud' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'cloud', self::$wp_piwik->is_configured() );
 			$this->show_input( 'matomo_user', __( 'Matomo subdomain', 'wp-piwik' ), __( 'Enter your Matomo Cloud subdomain. It is also part of your URL: https://SUBDOMAIN.matomo.cloud.', 'wp-piwik' ), 'cloud-matomo' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'cloud-matomo', self::$wp_piwik->is_configured() );
 			$this->show_input( 'piwik_token', __( 'Auth token', 'wp-piwik' ), __( 'Enter your Matomo auth token here. It is an alphanumerical code like 0a1b2c34d56e78901fa2bc3d45678efa.', 'wp-piwik' ) . ' ' . sprintf( __( 'See %1$sWP-Matomo FAQ%2$s.', 'wp-piwik' ), '<a href="https://wordpress.org/plugins/wp-piwik/faq/" target="_BLANK">', '</a>' ), false, '', '', self::$wp_piwik->is_configured(), true, 'password' );
@@ -745,6 +746,21 @@ class Settings extends \WP_Piwik\Admin {
 	</form>
 </div>
 		<?php
+	}
+
+	public function get_matomo_mode_options() {
+		$options = array(
+			'disabled' => __( 'Disabled (WP-Matomo will not connect to Matomo)', 'wp-piwik' ),
+			'http'     => __( 'Self-hosted (HTTP API, default)', 'wp-piwik' ),
+		);
+		// the PHP API is deprecated and is no longer offered, but a site that still uses it keeps
+		// the entry, so saving the settings page cannot silently change its connection method.
+		if ( 'php' === self::$settings->get_global_option( 'piwik_mode' ) ) {
+			$options['php'] = __( 'Self-hosted (PHP API, deprecated)', 'wp-piwik' );
+		}
+		$options['cloud-matomo'] = __( 'Cloud-hosted (Innocraft Cloud, *.matomo.cloud)', 'wp-piwik' );
+		$options['cloud']        = __( 'Cloud-hosted (InnoCraft Cloud, *.innocraft.cloud)', 'wp-piwik' );
+		return $options;
 	}
 
 	/**

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -129,16 +129,11 @@ class Settings extends \WP_Piwik\Admin {
 				$this->show_box( 'error', 'no', esc_html__( 'Neither cURL nor fopen are available. So WP-Matomo can not use the HTTP API and not connect to InnoCraft Cloud.', 'wp-piwik' ) . ' ' . sprintf( '<a href="%s">%s.</a>', 'https://wordpress.org/plugins/wp-piwik/faq/', esc_html__( 'More information', 'wp-piwik' ) ) );
 			}
 
-			// the message is already escaped, show_box() passes its content through unescaped
-			if ( 'php' === self::$settings->get_global_option( 'piwik_mode' ) ) {
-				$this->show_box( 'notice notice-warning', 'warning', \WP_Piwik::get_php_mode_deprecation_message() );
-			}
-
 			$description = sprintf( '%s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s', esc_html__( 'You can choose between two connection methods:', 'wp-piwik' ), esc_html__( 'Self-hosted (HTTP API, default)', 'wp-piwik' ), esc_html__( 'This is the default option for a self-hosted Matomo and should work for most configurations. WP-Matomo will connect to Matomo using http(s).', 'wp-piwik' ), esc_html__( 'Cloud-hosted', 'wp-piwik' ), esc_html__( 'If you are using a cloud-hosted Matomo by InnoCraft, you can simply use this option. Be careful to choose the option that matches your cloud domain (matomo.cloud or innocraft.cloud).', 'wp-piwik' ) );
 			$this->show_select(
 				'piwik_mode',
 				__( 'Matomo Mode', 'wp-piwik' ),
-				$this->get_matomo_mode_options(),
+				self::$settings->get_matomo_mode_options(),
 				$description,
 				'jQuery(\'tr.wp-piwik-mode-option\').addClass(\'hidden\'); jQuery(\'.wp-piwik-mode-option-\' + jQuery(\'#piwik_mode\').val()).removeClass(\'hidden\');',
 				false,
@@ -752,21 +747,6 @@ class Settings extends \WP_Piwik\Admin {
 		<?php
 	}
 
-	public function get_matomo_mode_options() {
-		$options = array(
-			'disabled' => __( 'Disabled (WP-Matomo will not connect to Matomo)', 'wp-piwik' ),
-			'http'     => __( 'Self-hosted (HTTP API, default)', 'wp-piwik' ),
-		);
-		// the PHP API is deprecated and is no longer offered, but a site that still uses it keeps
-		// the entry, so saving the settings page cannot silently change its connection method.
-		if ( 'php' === self::$settings->get_global_option( 'piwik_mode' ) ) {
-			$options['php'] = __( 'Self-hosted (PHP API, deprecated)', 'wp-piwik' );
-		}
-		$options['cloud-matomo'] = __( 'Cloud-hosted (Innocraft Cloud, *.matomo.cloud)', 'wp-piwik' );
-		$options['cloud']        = __( 'Cloud-hosted (InnoCraft Cloud, *.innocraft.cloud)', 'wp-piwik' );
-		return $options;
-	}
-
 	/**
 	 * Show a checkbox option
 	 *
@@ -948,7 +928,7 @@ class Settings extends \WP_Piwik\Admin {
 	 */
 	private function show_box( $type, $icon, $content ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		printf( '<tr><td colspan="2"><div class="%s"><p><span class="dashicons dashicons-%s"></span> %s</p></div></td></tr>', esc_attr( $type ), esc_attr( $icon ), $content );
+		printf( '<tr><td colspan="2"><div class="%s inline"><p><span class="dashicons dashicons-%s"></span> %s</p></div></td></tr>', esc_attr( $type ), esc_attr( $icon ), $content );
 	}
 
 	/**

--- a/classes/WP_Piwik/Admin/Settings.php
+++ b/classes/WP_Piwik/Admin/Settings.php
@@ -42,10 +42,13 @@ class Settings extends \WP_Piwik\Admin {
 		}
 		global $wp_roles;
 		?>
-<div id="plugin-options-wrap" class="widefat">
+		<div class="wrap">
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $this->get_headline( 1, 'admin-generic', 'Settings', true );
+		?>
+<div id="plugin-options-wrap" class="widefat">
+		<?php
 		if ( ! empty( $_GET['testscript'] ) ) {
 			$this->run_testscript();
 		}
@@ -145,7 +148,7 @@ class Settings extends \WP_Piwik\Admin {
 
 			$this->show_input( 'piwik_url', __( 'Matomo URL', 'wp-piwik' ), __( 'Enter your Matomo URL. This is the same URL you use to access your Matomo instance, e.g. http://www.example.com/matomo/.', 'wp-piwik' ), 'http' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'http', self::$wp_piwik->is_configured(), true );
 			if ( 'php' === self::$settings->get_global_option( 'piwik_mode' ) ) {
-				$this->show_input( 'piwik_path', __( 'Matomo path (deprecated)', 'wp-piwik' ), __( 'Enter the file path to your Matomo instance, e.g. /var/www/matomo/. Only used by the deprecated "Self-hosted (PHP API)" connection method.', 'wp-piwik' ), 'php' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'php', self::$wp_piwik->is_configured(), true );
+				$this->show_input( 'piwik_path', __( 'Matomo path (deprecated)', 'wp-piwik' ), __( 'Enter the file path to your Matomo instance, e.g. /var/www/matomo/. Only used by the deprecated "Self-hosted (PHP API)" connection method.', 'wp-piwik' ), false, 'wp-piwik-mode-option', 'php', self::$wp_piwik->is_configured(), true );
 			}
 			$this->show_input( 'piwik_user', __( 'Innocraft subdomain', 'wp-piwik' ), __( 'Enter your InnoCraft Cloud subdomain. It is also part of your URL: https://SUBDOMAIN.innocraft.cloud.', 'wp-piwik' ), 'cloud' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'cloud', self::$wp_piwik->is_configured() );
 			$this->show_input( 'matomo_user', __( 'Matomo subdomain', 'wp-piwik' ), __( 'Enter your Matomo Cloud subdomain. It is also part of your URL: https://SUBDOMAIN.matomo.cloud.', 'wp-piwik' ), 'cloud-matomo' !== self::$settings->get_global_option( 'piwik_mode' ), 'wp-piwik-mode-option', 'cloud-matomo', self::$wp_piwik->is_configured() );
@@ -744,6 +747,7 @@ class Settings extends \WP_Piwik\Admin {
 		<input type="hidden" name="wp-piwik[proxy_url]"
 			value="<?php echo esc_attr( self::$settings->get_global_option( 'proxy_url' ) ); ?>" />
 	</form>
+</div>
 </div>
 		<?php
 	}

--- a/classes/WP_Piwik/Request/Php.php
+++ b/classes/WP_Piwik/Request/Php.php
@@ -2,6 +2,13 @@
 
 namespace WP_Piwik\Request;
 
+/**
+ * Perform reporting API requests by loading Matomo into the WordPress process
+ *
+ * @deprecated 1.1.11 the "Self-hosted (PHP API)" connection method is deprecated and will be
+ *             removed in the next major release. Use \WP_Piwik\Request\Rest instead, see
+ *             \WP_Piwik::get_php_mode_deprecation_message().
+ */
 class Php extends \WP_Piwik\Request {
 
 	/**

--- a/classes/WP_Piwik/Settings.php
+++ b/classes/WP_Piwik/Settings.php
@@ -53,6 +53,7 @@ class Settings {
 		'tracking_code'    => 'prepare_tracking_code',
 		'noscript_code'    => 'prepare_nocscript_code',
 		'cookie_allowlist' => 'check_cookie_allowlist',
+		'piwik_mode'       => 'check_piwik_mode',
 	);
 
 	/**
@@ -422,6 +423,30 @@ class Settings {
 	 */
 	private function check_cookie_allowlist( $value ) {
 		return implode( ', ', self::parse_cookie_allowlist( $value ) );
+	}
+
+
+	public function check_piwik_mode( $value ) {
+		$options = $this->get_matomo_mode_options();
+		if ( ! in_array( $value, array_keys( $options ), true ) ) {
+			return $this->get_global_option( 'piwik_mode' );
+		}
+		return $value;
+	}
+
+	public function get_matomo_mode_options() {
+		$options = array(
+			'disabled' => __( 'Disabled (WP-Matomo will not connect to Matomo)', 'wp-piwik' ),
+			'http'     => __( 'Self-hosted (HTTP API, default)', 'wp-piwik' ),
+		);
+		// the PHP API is deprecated and is no longer offered, but a site that still uses it keeps
+		// the entry, so saving the settings page cannot silently change its connection method.
+		if ( 'php' === $this->get_global_option( 'piwik_mode' ) ) {
+			$options['php'] = __( 'Self-hosted (PHP API, deprecated)', 'wp-piwik' );
+		}
+		$options['cloud-matomo'] = __( 'Cloud-hosted (Innocraft Cloud, *.matomo.cloud)', 'wp-piwik' );
+		$options['cloud']        = __( 'Cloud-hosted (InnoCraft Cloud, *.innocraft.cloud)', 'wp-piwik' );
+		return $options;
 	}
 
 	/**

--- a/classes/WP_Piwik/Shortcode.php
+++ b/classes/WP_Piwik/Shortcode.php
@@ -63,6 +63,17 @@ class Shortcode {
 	}
 
 	/**
+	 * Get the modules that are deprecated and will be removed in the next major release
+	 *
+	 * @see \WP_Piwik::get_deprecated_shortcode_message()
+	 *
+	 * @return string[] module names of the deprecated shortcodes
+	 */
+	public static function get_deprecated_modules() {
+		return array( 'overview', 'post' );
+	}
+
+	/**
 	 * Execute the shortcode
 	 *
 	 * @param array|string $attributes
@@ -76,6 +87,12 @@ class Shortcode {
 			$attributes
 		);
 		$attributes = $this->sanitize_attributes( $attributes );
+
+		if ( in_array( $attributes['module'], self::get_deprecated_modules(), true ) ) {
+			// there is no way to find these by looking at the site, so the admin notice
+			// is driven by what actually renders
+			$this->wp_piwik->record_deprecated_shortcode_use( $attributes['module'] );
+		}
 
 		// authorize before any API request is sent
 		$denial = $this->check_authorization( $attributes );

--- a/readme.txt
+++ b/readme.txt
@@ -35,17 +35,12 @@ To use this plugin the Matomo web analytics application is required. If you do n
 = Shortcodes =
 You can use following shortcodes if activated:
 
-    [wp-piwik module="overview" title="" period="day" date="yesterday"]
-Shows overview table like WP-Matomo's overview dashboard. See Matomo API documentation on VisitsSummary.get to get more information on period and day. Multiple data arrays will be cumulated. If you fill the title attribute, its content will be shown in the table's title.
-
     [wp-piwik module="opt-out" language="en" width="100%" height="200px"]
-Shows the Matomo opt-out Iframe. You can change the Iframe's language by the language attribute (e.g. de for German language) and its width and height using the corresponding attributes.
+Shows the Matomo opt-out Iframe. You can change the Iframe's language by the language attribute (e.g. de for German language) and its width and height using the corresponding attributes. This shortcode is not deprecated.
 
-    [wp-piwik module="post" period="range" date="last30" key="sum_daily_nb_uniq_visitors"]
-Shows the chosen keys value related to the current post. You can define a date (format: lastN, previousN, today, yesterday, YYYY-MM-DD or YYYY-MM-DD,YYYY-MM-DD) and the desired value's key (e.g., sum_daily_nb_uniq_visitors, nb_visits or nb_hits - for details see Matomo's API method Actions.getPageUrl using a range). The optional url attribute reports on another post of this site instead of the current one; it is only accepted if it resolves to a post the author of the containing post is allowed to read.
+= Embedding Matomo Reports =
 
-    [wp-piwik]
-is equal to *[wp-piwik module="overview" title="" period="day" date="yesterday"]*.
+If you'd like to embed Matomo reports in WordPress pages and posts, use Matomo's [Widgetize](https://matomo.org/faq/reports/embed-a-matomo-report-in-a-html-page/) feature, with a dedicated read-only auth token created in Matomo.
 
 = Credits and Acknowledgements =
 
@@ -76,6 +71,14 @@ The response output contains...
 - **bool(false)** and no further HTTP response code: The Matomo server does not respond. Very often, this is caused by firewall or mod_security settings. Check your server logfiles to get further information. If you aren’t sure about this, please contact your web hoster for support.
 
 If this does not help as well, feel free to open a [topic in the support forum](https://wordpress.org/support/plugin/wp-piwik/). Please share all available information including the test script result, if possible.
+
+= WP-Matomo tells me the statistics shortcodes are deprecated. What should I do? =
+
+`[wp-piwik]`, `[wp-piwik module="overview"]` and `[wp-piwik module="post"]` report Matomo data into a page. They are considred insecure and redundant, so they will be removed in the next major release of WP-Matomo, which will be published by November 2026 at the latest.
+
+Matomo's [Widgetize](https://matomo.org/faq/reports/embed-a-matomo-report-in-a-html-page/) feature is the supported replacement: Matomo serves the report itself and you embed it. Create a dedicated auth token in Matomo with view access only, and use that token for the widget, so an embedded report cannot reach anything else.
+
+The opt-out shortcode, `[wp-piwik module="opt-out"]`, is **not** deprecated. It will continue to function.
 
 = WP-Matomo tells me the "Self-hosted (PHP API)" connection method is deprecated. What should I do? =
 
@@ -153,6 +156,7 @@ Add WP-Matomo to your /wp-content/plugins folder and enable it as [Network Plugi
 == Changelog ==
 
 = 1.1.11 =
+* Deprecation: the overview and post shortcodes ([wp-piwik], [wp-piwik module="overview"] and [wp-piwik module="post"]) are deprecated and will be removed in the next major release, which will be published by November 2026 at the latest. Matomo's Widgetize feature is the supported replacement: https://matomo.org/faq/reports/embed-a-matomo-report-in-a-html-page/. The opt-out shortcode is not deprecated.
 * Deprecation: the "Self-hosted (PHP API)" connection method is deprecated and will be removed in the next major release, which will be published by November 2026 at the latest. It is no longer offered when connecting a new site, and sites still using it are shown a notice. Switch to "Self-hosted (HTTP API)" and enter the URL of your Matomo instance instead.
 * Security: the overview and post shortcodes are no longer rendered if the author of the post containing them is not allowed to see the statistics.
 * Security: the url attribute of the post shortcode is now restricted to posts the author is allowed to read.

--- a/readme.txt
+++ b/readme.txt
@@ -74,7 +74,7 @@ If this does not help as well, feel free to open a [topic in the support forum](
 
 = WP-Matomo tells me the statistics shortcodes are deprecated. What should I do? =
 
-`[wp-piwik]`, `[wp-piwik module="overview"]` and `[wp-piwik module="post"]` report Matomo data into a page. They are considred insecure and redundant, so they will be removed in the next major release of WP-Matomo, which will be published by November 2026 at the latest.
+`[wp-piwik]`, `[wp-piwik module="overview"]` and `[wp-piwik module="post"]` report Matomo data into a page. They are considered insecure and redundant, so they will be removed in the next major release of WP-Matomo, which will be published by November 2026 at the latest.
 
 Matomo's [Widgetize](https://matomo.org/faq/reports/embed-a-matomo-report-in-a-html-page/) feature is the supported replacement: Matomo serves the report itself and you embed it. Create a dedicated auth token in Matomo with view access only, and use that token for the widget, so an embedded report cannot reach anything else.
 

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,12 @@ The response output contains...
 
 If this does not help as well, feel free to open a [topic in the support forum](https://wordpress.org/support/plugin/wp-piwik/). Please share all available information including the test script result, if possible.
 
+= WP-Matomo tells me the "Self-hosted (PHP API)" connection method is deprecated. What should I do? =
+
+The PHP API loads Matomo into the WordPress process instead of requesting the reports over http(s). That gives the Matomo code full access to your WordPress installation and offers nothing the HTTP API does not, so it is deprecated and will be removed in the next major release of WP-Matomo, which will be published by November 2026 at the latest.
+
+To switch over, open the WP-Matomo settings, choose "Self-hosted (HTTP API, default)" as the Matomo Mode and enter the URL you use to access your Matomo instance in the browser, e.g. http://www.example.com/matomo/. Your auth token and site selection stay as they are. Until you switch, the PHP API keeps working as before.
+
 = PHP Compatibility Checker reports PHP7 compatbility issues with WP-Matomo. =
 
 The Compatibility Checker shows two false positives. WP-Matomo is 100% PHP7 compatible, you can ignore the report.
@@ -147,6 +153,7 @@ Add WP-Matomo to your /wp-content/plugins folder and enable it as [Network Plugi
 == Changelog ==
 
 = 1.1.11 =
+* Deprecation: the "Self-hosted (PHP API)" connection method is deprecated and will be removed in the next major release, which will be published by November 2026 at the latest. It is no longer offered when connecting a new site, and sites still using it are shown a notice. Switch to "Self-hosted (HTTP API)" and enter the URL of your Matomo instance instead.
 * Security: the overview and post shortcodes are no longer rendered if the author of the post containing them is not allowed to see the statistics.
 * Security: the url attribute of the post shortcode is now restricted to posts the author is allowed to read.
 * Security: shortcodes ignore period, date and language attributes Matomo would not accept, and fall back to their default instead.

--- a/tests/phpunit/AdminSettingsTest.php
+++ b/tests/phpunit/AdminSettingsTest.php
@@ -6,26 +6,6 @@ use WP_Piwik\Admin\Settings as AdminSettings;
 
 class AdminSettingsTest extends WP_Piwik_TestCase {
 
-	public function test_get_matomo_mode_options_should_not_offer_the_deprecated_php_api() {
-		$admin = new AdminSettings( new \WP_Piwik_Test_Mock_Plugin(), $this->create_settings( [ 'piwik_mode' => 'http' ] ) );
-
-		$this->assertSame(
-			[ 'disabled', 'http', 'cloud-matomo', 'cloud' ],
-			array_keys( $admin->get_matomo_mode_options() )
-		);
-	}
-
-	public function test_get_matomo_mode_options_should_keep_the_php_api_for_a_site_still_using_it() {
-		$admin = new AdminSettings( new \WP_Piwik_Test_Mock_Plugin(), $this->create_settings( [ 'piwik_mode' => 'php' ] ) );
-
-		$options = $admin->get_matomo_mode_options();
-
-		// dropping the entry would make saving the settings page silently switch the
-		// site to another connection method
-		$this->assertSame( [ 'disabled', 'http', 'php', 'cloud-matomo', 'cloud' ], array_keys( $options ) );
-		$this->assertStringContainsString( 'deprecated', $options['php'] );
-	}
-
 	public function test_show_select_marks_the_stored_option_as_selected_for_integer_keys() {
 		// site_id stored as an integer.
 		update_option( 'wp-piwik-site_id', 2 );

--- a/tests/phpunit/AdminSettingsTest.php
+++ b/tests/phpunit/AdminSettingsTest.php
@@ -6,16 +6,24 @@ use WP_Piwik\Admin\Settings as AdminSettings;
 
 class AdminSettingsTest extends WP_Piwik_TestCase {
 
-	private function render_select( $settings, $id, array $options, $is_global ) {
-		$admin = new AdminSettings( new \WP_Piwik_Test_Mock_Plugin(), $settings );
-		ob_start();
-		$admin->show_select( $id, 'Select site', $options, '', '', false, '', true, $is_global );
-		return ob_get_clean();
+	public function test_get_matomo_mode_options_should_not_offer_the_deprecated_php_api() {
+		$admin = new AdminSettings( new \WP_Piwik_Test_Mock_Plugin(), $this->create_settings( [ 'piwik_mode' => 'http' ] ) );
+
+		$this->assertSame(
+			[ 'disabled', 'http', 'cloud-matomo', 'cloud' ],
+			array_keys( $admin->get_matomo_mode_options() )
+		);
 	}
 
-	private function get_selected_option_values( $html ) {
-		preg_match_all( '/<option value="([^"]*)"[^>]*selected="selected"/', $html, $matches );
-		return $matches[1];
+	public function test_get_matomo_mode_options_should_keep_the_php_api_for_a_site_still_using_it() {
+		$admin = new AdminSettings( new \WP_Piwik_Test_Mock_Plugin(), $this->create_settings( [ 'piwik_mode' => 'php' ] ) );
+
+		$options = $admin->get_matomo_mode_options();
+
+		// dropping the entry would make saving the settings page silently switch the
+		// site to another connection method
+		$this->assertSame( [ 'disabled', 'http', 'php', 'cloud-matomo', 'cloud' ], array_keys( $options ) );
+		$this->assertStringContainsString( 'deprecated', $options['php'] );
 	}
 
 	public function test_show_select_marks_the_stored_option_as_selected_for_integer_keys() {
@@ -66,5 +74,17 @@ class AdminSettingsTest extends WP_Piwik_TestCase {
 		$html = $this->render_select( $settings, 'default_date', $options, true );
 
 		$this->assertSame( [ 'last_month' ], $this->get_selected_option_values( $html ) );
+	}
+
+	private function render_select( $settings, $id, array $options, $is_global ) {
+		$admin = new AdminSettings( new \WP_Piwik_Test_Mock_Plugin(), $settings );
+		ob_start();
+		$admin->show_select( $id, 'Select site', $options, '', '', false, '', true, $is_global );
+		return ob_get_clean();
+	}
+
+	private function get_selected_option_values( $html ) {
+		preg_match_all( '/<option value="([^"]*)"[^>]*selected="selected"/', $html, $matches );
+		return $matches[1];
 	}
 }

--- a/tests/phpunit/SettingsTest.php
+++ b/tests/phpunit/SettingsTest.php
@@ -297,6 +297,94 @@ class SettingsTest extends WP_Piwik_TestCase {
 		}
 	}
 
+	public function test_get_matomo_mode_options_should_not_offer_the_deprecated_php_api() {
+		$settings = $this->create_settings( [ 'piwik_mode' => 'http' ] );
+
+		$this->assertSame(
+			[ 'disabled', 'http', 'cloud-matomo', 'cloud' ],
+			array_keys( $settings->get_matomo_mode_options() )
+		);
+	}
+
+	public function test_get_matomo_mode_options_should_keep_the_php_api_for_a_site_still_using_it() {
+		$settings = $this->create_settings( [ 'piwik_mode' => 'php' ] );
+
+		$options = $settings->get_matomo_mode_options();
+
+		// dropping the entry would make saving the settings page silently switch the
+		// site to another connection method
+		$this->assertSame( [ 'disabled', 'http', 'php', 'cloud-matomo', 'cloud' ], array_keys( $options ) );
+		$this->assertStringContainsString( 'deprecated', $options['php'] );
+	}
+
+	/**
+	 * @dataProvider get_offered_connection_methods
+	 */
+	public function test_check_piwik_mode_should_keep_a_connection_method_the_settings_page_offers( $piwik_mode ) {
+		$settings = $this->create_settings();
+
+		$this->assertSame( $piwik_mode, $settings->check_piwik_mode( $piwik_mode ) );
+	}
+
+	public function get_offered_connection_methods() {
+		return [
+			'disabled'     => [ 'disabled' ],
+			'http'         => [ 'http' ],
+			'cloud'        => [ 'cloud' ],
+			'cloud-matomo' => [ 'cloud-matomo' ],
+		];
+	}
+
+	public function test_check_piwik_mode_should_keep_the_deprecated_php_api_for_a_site_still_using_it() {
+		$settings = $this->create_settings( [ 'piwik_mode' => 'php' ] );
+		$this->assertSame( 'php', $settings->check_piwik_mode( 'php' ) );
+	}
+
+	public function test_check_piwik_mode_should_reject_the_deprecated_php_api_for_a_site_not_using_it() {
+		$settings = $this->create_settings( [ 'piwik_mode' => 'cloud' ] );
+		$this->assertSame( 'cloud', $settings->check_piwik_mode( 'php' ) );
+	}
+
+	/**
+	 * @dataProvider get_values_that_are_not_a_connection_method
+	 */
+	public function test_check_piwik_mode_should_reject_a_value_that_is_not_a_connection_method( $value ) {
+		$settings = $this->create_settings( [ 'piwik_mode' => 'cloud' ] );
+		$this->assertSame( 'cloud', $settings->check_piwik_mode( $value ) );
+	}
+
+	public function get_values_that_are_not_a_connection_method() {
+		return [
+			'an unknown method' => [ 'ftp' ],
+			'the option label'  => [ 'Self-hosted (HTTP API, default)' ],
+			'an empty string'   => [ '' ],
+			'null'              => [ null ],
+			'an array'          => [ [ 'http' ] ],
+		];
+	}
+
+	public function test_apply_changes_should_reject_a_connection_method_the_settings_page_does_not_offer() {
+		$settings = $this->create_settings( [ 'piwik_mode' => 'cloud' ] );
+
+		$settings->apply_changes( [ 'piwik_mode' => 'php' ] );
+
+		$this->assertSame( 'cloud', $settings->get_global_option( 'piwik_mode' ) );
+	}
+
+	public function test_apply_changes_should_keep_the_deprecated_php_api_for_a_site_still_using_it() {
+		$settings = $this->create_settings( [ 'piwik_mode' => 'php' ] );
+
+		$settings->apply_changes(
+			[
+				'piwik_mode' => 'php',
+				'piwik_path' => '/var/www/matomo/',
+			]
+		);
+
+		$this->assertSame( 'php', $settings->get_global_option( 'piwik_mode' ) );
+		$this->assertSame( '/var/www/matomo/', $settings->get_global_option( 'piwik_path' ) );
+	}
+
 	public function test_check_network_activation_is_false_when_not_network_activated() {
 		$settings = $this->create_settings();
 

--- a/tests/phpunit/ShortcodeTest.php
+++ b/tests/phpunit/ShortcodeTest.php
@@ -726,7 +726,7 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 
 		$this->render( 'module=overview' );
 
-		$this->assertSame( [], $this->get_recorded_deprecated_shortcodes(), 'nothing was rendered, but the shortcode use still needs to be warned about' );
+		$this->assertSame( [ 'overview' ], $this->get_recorded_deprecated_shortcodes(), 'nothing was rendered, but the shortcode use still needs to be warned about' );
 	}
 
 	public function test_render_should_not_write_the_record_again_for_a_module_already_on_it() {

--- a/tests/phpunit/ShortcodeTest.php
+++ b/tests/phpunit/ShortcodeTest.php
@@ -690,6 +690,67 @@ class ShortcodeTest extends WP_Piwik_TestCase {
 		$this->assertStringContainsString( 'not allowed to see the statistics', $output );
 	}
 
+	/**
+	 * @dataProvider get_deprecated_shortcodes
+	 */
+	public function test_render_should_record_a_deprecated_module_it_rendered( $attributes, $module ) {
+		$this->create_post_and_set_as_current( $this->create_author( true ) );
+
+		$this->render( $attributes );
+
+		$this->assertSame( [ $module ], $this->get_recorded_deprecated_shortcodes() );
+	}
+
+	public function get_deprecated_shortcodes() {
+		return [
+			'overview'            => [ 'module=overview', 'overview' ],
+			'post'                => [ 'module=post key=nb_visits', 'post' ],
+			'overview by default' => [ '', 'overview' ],
+		];
+	}
+
+	public function test_render_should_not_record_the_opt_out_module() {
+		$this->render( 'module=opt-out' );
+
+		$this->assertSame( [], $this->get_recorded_deprecated_shortcodes(), 'the opt-out shortcode is not deprecated' );
+	}
+
+	public function test_render_should_not_record_an_unknown_module() {
+		$this->render( 'module=nope' );
+
+		$this->assertSame( [], $this->get_recorded_deprecated_shortcodes() );
+	}
+
+	public function test_render_should_record_a_shortcode_it_refused_to_render() {
+		$this->create_post_and_set_as_current( $this->create_author( false ) );
+
+		$this->render( 'module=overview' );
+
+		$this->assertSame( [], $this->get_recorded_deprecated_shortcodes(), 'nothing was rendered, but the shortcode use still needs to be warned about' );
+	}
+
+	public function test_render_should_not_write_the_record_again_for_a_module_already_on_it() {
+		$writes = 0;
+		add_filter(
+			'pre_update_option_' . \WP_Piwik::DEPRECATED_SHORTCODES_OPTION,
+			function ( $value ) use ( &$writes ) {
+				++$writes;
+				return $value;
+			}
+		);
+
+		// the shortcode renders on the front end, so it must not write on every page view
+		$this->render( 'module=overview' );
+		$this->render( 'module=overview' );
+
+		$this->assertSame( 1, $writes );
+		$this->assertSame( [ 'overview' ], $this->get_recorded_deprecated_shortcodes() );
+	}
+
+	private function get_recorded_deprecated_shortcodes() {
+		return $GLOBALS['wp-piwik']->get_recorded_deprecated_shortcodes();
+	}
+
 	private function render( $attributes ) {
 		$shortcode = new Shortcode( $GLOBALS['wp-piwik'], \WP_Piwik::get_settings() );
 		return $shortcode->render( shortcode_parse_atts( $attributes ) );

--- a/tests/phpunit/WP_PiwikTest.php
+++ b/tests/phpunit/WP_PiwikTest.php
@@ -41,7 +41,7 @@ class WP_PiwikTest extends WP_Piwik_TestCase {
 		$output = $this->render_php_mode_deprecation_notice();
 
 		$this->assertStringContainsString( 'notice-warning', $output );
-		$this->assertStringContainsString( 'The &quot;Self-hosted (PHP API)&quot; connection method is deprecated.', $output );
+		$this->assertStringContainsString( 'The &quot;Self-hosted (PHP API)&quot; connection method is deprecated', $output );
 		$this->assertStringContainsString( 'November 2026', $output );
 		$this->assertStringContainsString( 'page=wp-matomo-settings', $output );
 	}
@@ -70,6 +70,216 @@ class WP_PiwikTest extends WP_Piwik_TestCase {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$this->assertSame( '', $this->render_php_mode_deprecation_notice() );
+	}
+
+	public function test_record_deprecated_shortcode_use_should_keep_one_entry_per_module() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'post' );
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'post' );
+
+		$this->assertSame(
+			array( 'overview', 'post' ),
+			$GLOBALS['wp-piwik']->get_recorded_deprecated_shortcodes(),
+			'the modules are reported in the order the shortcode class declares them'
+		);
+	}
+
+	public function test_get_recorded_deprecated_shortcodes_should_ignore_modules_that_are_not_deprecated() {
+		update_option(
+			\WP_Piwik::DEPRECATED_SHORTCODES_OPTION,
+			array(
+				'modules' => array(
+					'overview' => time(),
+					'opt-out'  => time(),
+					'nope'     => time(),
+				),
+			)
+		);
+
+		$this->assertSame( array( 'overview' ), $GLOBALS['wp-piwik']->get_recorded_deprecated_shortcodes() );
+	}
+
+	/**
+	 * @dataProvider get_option_values_the_plugin_never_wrote
+	 */
+	public function test_get_recorded_deprecated_shortcodes_should_ignore_a_value_it_did_not_write( $value ) {
+		update_option( \WP_Piwik::DEPRECATED_SHORTCODES_OPTION, $value );
+
+		$this->assertSame( array(), $GLOBALS['wp-piwik']->get_recorded_deprecated_shortcodes() );
+	}
+
+	public function get_option_values_the_plugin_never_wrote() {
+		return array(
+			'a string'                => array( 'overview' ),
+			'the flat list of a beta' => array( array( 'overview', 'post' ) ),
+			'timestamps that are not' => array( array( 'modules' => array( 'overview' => 'yesterday' ) ) ),
+		);
+	}
+
+	public function test_dismiss_deprecated_shortcode_notice_should_hide_a_notice_that_was_showing() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_settings_administrator();
+
+		$GLOBALS['wp-piwik']->dismiss_deprecated_shortcode_notice();
+
+		$this->assertSame( '', $this->render_deprecated_shortcode_notice() );
+	}
+
+	public function test_record_deprecated_shortcode_use_should_leave_the_notice_dismissed_within_the_dismissal_period() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$GLOBALS['wp-piwik']->dismiss_deprecated_shortcode_notice();
+		$this->log_in_as_settings_administrator();
+
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+
+		$this->assertSame( '', $this->render_deprecated_shortcode_notice() );
+	}
+
+	public function test_dismiss_deprecated_shortcode_notice_should_keep_the_notice_away_for_a_week() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+
+		$GLOBALS['wp-piwik']->dismiss_deprecated_shortcode_notice();
+
+		$record = get_option( \WP_Piwik::DEPRECATED_SHORTCODES_OPTION );
+		$this->assertEqualsWithDelta( time() + WEEK_IN_SECONDS, $record['dismissed_until'], 5 );
+	}
+
+	public function test_record_deprecated_shortcode_use_should_show_the_notice_again_once_the_dismissal_ran_out() {
+		$this->set_up_a_dismissal_that_ran_out();
+		$this->log_in_as_settings_administrator();
+		$this->assertSame( '', $this->render_deprecated_shortcode_notice(), 'precondition: nothing has rendered since' );
+
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+
+		$this->assertStringContainsString(
+			'The statistics shortcodes are deprecated',
+			$this->render_deprecated_shortcode_notice()
+		);
+	}
+
+	public function test_get_recorded_deprecated_shortcodes_should_stay_empty_when_nothing_rendered_after_the_dismissal_ran_out() {
+		$this->set_up_a_dismissal_that_ran_out();
+
+		$this->assertSame(
+			array(),
+			$GLOBALS['wp-piwik']->get_recorded_deprecated_shortcodes(),
+			'a site that removed its shortcodes in the meantime is not warned again'
+		);
+	}
+
+	public function test_on_deprecated_shortcode_notice_dismissed_should_dismiss_the_notice() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_settings_administrator();
+
+		$this->request_a_notice_dismissal( wp_create_nonce( \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG ) );
+
+		$this->assertSame( '', $this->render_deprecated_shortcode_notice() );
+	}
+
+	public function test_on_deprecated_shortcode_notice_dismissed_should_reject_a_request_without_a_valid_nonce() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_settings_administrator();
+
+		$this->expectException( \WPDieException::class );
+		$this->request_a_notice_dismissal( 'not-a-nonce' );
+	}
+
+	public function test_on_deprecated_shortcode_notice_dismissed_should_not_let_a_user_who_cannot_change_the_setting_dismiss_it() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->request_a_notice_dismissal( wp_create_nonce( \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG ) );
+
+		$this->log_in_as_settings_administrator();
+		$this->assertStringContainsString(
+			'The statistics shortcodes are deprecated',
+			$this->render_deprecated_shortcode_notice()
+		);
+	}
+
+	public function test_show_deprecated_shortcode_notice_if_in_use_should_warn_a_site_rendering_a_deprecated_shortcode() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_settings_administrator();
+
+		$output = $this->render_deprecated_shortcode_notice();
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'The statistics shortcodes are deprecated', $output );
+		$this->assertStringContainsString( 'November 2026', $output );
+		$this->assertStringContainsString( 'Widgetize', $output );
+		$this->assertStringContainsString( 'read-only auth token', $output );
+		$this->assertStringContainsString( 'https://matomo.org/docs/embed-piwik-report/', $output );
+		$this->assertStringContainsString( \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG, $output, 'the notice can be dismissed' );
+	}
+
+	public function test_show_deprecated_shortcode_notice_if_in_use_should_name_only_the_modules_the_site_rendered() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'post' );
+		$this->log_in_as_settings_administrator();
+
+		$output = $this->render_deprecated_shortcode_notice();
+
+		$this->assertStringContainsString( '<code>[wp-piwik module=&quot;post&quot;]</code>', $output );
+		$this->assertStringNotContainsString( 'module=&quot;overview&quot;', $output );
+	}
+
+	public function test_show_deprecated_shortcode_notice_if_in_use_should_say_the_opt_out_shortcode_keeps_working() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_settings_administrator();
+
+		$this->assertStringContainsString(
+			'The <code>[wp-piwik module=&quot;opt-out&quot;]</code> shortcode is not deprecated and will continue to function.',
+			$this->render_deprecated_shortcode_notice()
+		);
+	}
+
+	public function test_show_deprecated_shortcode_notice_if_in_use_should_stay_silent_when_no_deprecated_shortcode_was_rendered() {
+		$this->log_in_as_settings_administrator();
+
+		$this->assertSame( '', $this->render_deprecated_shortcode_notice() );
+	}
+
+	public function test_show_deprecated_shortcode_notice_if_in_use_should_stay_silent_for_users_who_cannot_change_the_setting() {
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->assertSame( '', $this->render_deprecated_shortcode_notice() );
+	}
+
+	private function render_deprecated_shortcode_notice() {
+		ob_start();
+		$GLOBALS['wp-piwik']->show_deprecated_shortcode_notice_if_in_use();
+		return ob_get_clean();
+	}
+
+	private function set_up_a_dismissal_that_ran_out() {
+		update_option(
+			\WP_Piwik::DEPRECATED_SHORTCODES_OPTION,
+			array(
+				'modules'         => array( 'overview' => time() - 3 * WEEK_IN_SECONDS ),
+				'dismissed_until' => time() - WEEK_IN_SECONDS,
+			)
+		);
+	}
+
+	/**
+	 * @param string $nonce nonce the request carries
+	 */
+	private function request_a_notice_dismissal( $nonce ) {
+		$_GET[ \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG ]     = '1';
+		$_REQUEST[ \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG ] = '1';
+		$_REQUEST['_wpnonce']                                = $nonce;
+
+		// blocking the redirect keeps the handler from exiting the test run
+		add_filter( 'wp_redirect', '__return_false' );
+		try {
+			$GLOBALS['wp-piwik']->on_deprecated_shortcode_notice_dismissed();
+		} finally {
+			unset(
+				$_GET[ \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG ],
+				$_REQUEST[ \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG ],
+				$_REQUEST['_wpnonce']
+			);
+		}
 	}
 
 	private function render_php_mode_deprecation_notice() {

--- a/tests/phpunit/WP_PiwikTest.php
+++ b/tests/phpunit/WP_PiwikTest.php
@@ -11,14 +11,17 @@ class WP_PiwikTest extends WP_Piwik_TestCase {
 
 		$settings              = \WP_Piwik::get_settings();
 		$this->settings_backup = array(
-			'piwik_url' => $settings->get_global_option( 'piwik_url' ),
+			'piwik_url'  => $settings->get_global_option( 'piwik_url' ),
+			'piwik_mode' => $settings->get_global_option( 'piwik_mode' ),
 		);
 
 		$settings->set_global_option( 'piwik_url', 'https://matomo.example.org/' );
 	}
 
 	public function tear_down() {
-		\WP_Piwik::get_settings()->set_global_option( 'piwik_url', $this->settings_backup['piwik_url'] );
+		$settings = \WP_Piwik::get_settings();
+		$settings->set_global_option( 'piwik_url', $this->settings_backup['piwik_url'] );
+		$settings->set_global_option( 'piwik_mode', $this->settings_backup['piwik_mode'] );
 
 		parent::tear_down();
 	}
@@ -29,5 +32,58 @@ class WP_PiwikTest extends WP_Piwik_TestCase {
 		$output = $GLOBALS['wp-piwik']->shortcode( shortcode_parse_atts( 'module=opt-out' ) );
 
 		$this->assertStringContainsString( '<iframe', $output );
+	}
+
+	public function test_show_php_mode_deprecation_notice_if_in_use_should_warn_a_site_still_connecting_through_the_php_api() {
+		\WP_Piwik::get_settings()->set_global_option( 'piwik_mode', 'php' );
+		$this->log_in_as_settings_administrator();
+
+		$output = $this->render_php_mode_deprecation_notice();
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'The &quot;Self-hosted (PHP API)&quot; connection method is deprecated.', $output );
+		$this->assertStringContainsString( 'November 2026', $output );
+		$this->assertStringContainsString( 'page=wp-matomo-settings', $output );
+	}
+
+	/**
+	 * @dataProvider get_connection_methods_that_are_not_the_php_api
+	 */
+	public function test_show_php_mode_deprecation_notice_if_in_use_should_stay_silent_for_every_other_connection_method( $piwik_mode ) {
+		\WP_Piwik::get_settings()->set_global_option( 'piwik_mode', $piwik_mode );
+		$this->log_in_as_settings_administrator();
+
+		$this->assertSame( '', $this->render_php_mode_deprecation_notice() );
+	}
+
+	public function get_connection_methods_that_are_not_the_php_api() {
+		return array(
+			'disabled'     => array( 'disabled' ),
+			'http'         => array( 'http' ),
+			'cloud'        => array( 'cloud' ),
+			'cloud-matomo' => array( 'cloud-matomo' ),
+		);
+	}
+
+	public function test_show_php_mode_deprecation_notice_if_in_use_should_stay_silent_for_users_who_cannot_change_the_setting() {
+		\WP_Piwik::get_settings()->set_global_option( 'piwik_mode', 'php' );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->assertSame( '', $this->render_php_mode_deprecation_notice() );
+	}
+
+	private function render_php_mode_deprecation_notice() {
+		ob_start();
+		$GLOBALS['wp-piwik']->show_php_mode_deprecation_notice_if_in_use();
+		return ob_get_clean();
+	}
+
+	private function log_in_as_settings_administrator() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		if ( is_multisite() ) {
+			// on a network, activate_plugins is reserved for super admins
+			grant_super_admin( $user_id );
+		}
+		wp_set_current_user( $user_id );
 	}
 }

--- a/tests/phpunit/WP_PiwikTest.php
+++ b/tests/phpunit/WP_PiwikTest.php
@@ -245,10 +245,144 @@ class WP_PiwikTest extends WP_Piwik_TestCase {
 		$this->assertSame( '', $this->render_deprecated_shortcode_notice() );
 	}
 
+	public function test_record_deprecated_shortcode_use_should_store_the_record_for_the_whole_network() {
+		$this->network_activate_the_plugin();
+
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+
+		$record = get_site_option( \WP_Piwik::DEPRECATED_SHORTCODES_OPTION );
+		$this->assertArrayHasKey( 'overview', $record['modules'] );
+		$this->assertFalse(
+			get_option( \WP_Piwik::DEPRECATED_SHORTCODES_OPTION ),
+			'a network wide plugin keeps the record out of the individual sites'
+		);
+	}
+
+	public function test_get_recorded_deprecated_shortcodes_should_report_a_network_wide_record_from_another_site() {
+		$this->network_activate_the_plugin();
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+
+		switch_to_blog( self::factory()->blog->create() );
+		try {
+			$this->assertSame( array( 'overview' ), $GLOBALS['wp-piwik']->get_recorded_deprecated_shortcodes() );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	public function test_show_deprecated_shortcode_notice_if_in_use_should_warn_a_super_admin_on_a_network() {
+		$this->network_activate_the_plugin();
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_settings_administrator();
+
+		$this->assertStringContainsString(
+			'The statistics shortcodes are deprecated',
+			$this->render_deprecated_shortcode_notice()
+		);
+	}
+
+	public function test_show_deprecated_shortcode_notice_if_in_use_should_stay_silent_for_a_network_user_who_cannot_manage_sites() {
+		$this->network_activate_the_plugin();
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_a_site_administrator_who_can_activate_plugins();
+
+		$this->assertSame( '', $this->render_deprecated_shortcode_notice() );
+	}
+
+	public function test_show_deprecated_shortcode_notice_if_in_use_should_warn_a_site_administrator_when_the_plugin_is_not_network_activated() {
+		$this->skip_unless_multisite();
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_a_site_administrator_who_can_activate_plugins();
+
+		$this->assertStringContainsString(
+			'The statistics shortcodes are deprecated',
+			$this->render_deprecated_shortcode_notice()
+		);
+	}
+
+	public function test_on_deprecated_shortcode_notice_dismissed_should_dismiss_the_notice_for_the_whole_network() {
+		$this->network_activate_the_plugin();
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_settings_administrator();
+
+		$this->request_a_notice_dismissal( wp_create_nonce( \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG ) );
+
+		$record = get_site_option( \WP_Piwik::DEPRECATED_SHORTCODES_OPTION );
+		$this->assertGreaterThan( time(), $record['dismissed_until'] );
+		$this->assertSame( '', $this->render_deprecated_shortcode_notice() );
+	}
+
+	public function test_on_deprecated_shortcode_notice_dismissed_should_not_let_a_network_user_who_cannot_manage_sites_dismiss_it() {
+		$this->network_activate_the_plugin();
+		$GLOBALS['wp-piwik']->record_deprecated_shortcode_use( 'overview' );
+		$this->log_in_as_a_site_administrator_who_can_activate_plugins();
+
+		$this->request_a_notice_dismissal( wp_create_nonce( \WP_Piwik::DISMISS_SHORTCODE_NOTICE_ARG ) );
+
+		$this->log_in_as_settings_administrator();
+		$this->assertStringContainsString(
+			'The statistics shortcodes are deprecated',
+			$this->render_deprecated_shortcode_notice()
+		);
+	}
+
+	public function test_show_php_mode_deprecation_notice_if_in_use_should_warn_a_super_admin_on_a_network() {
+		$this->network_activate_the_plugin();
+		\WP_Piwik::get_settings()->set_global_option( 'piwik_mode', 'php' );
+		$this->log_in_as_settings_administrator();
+
+		$this->assertStringContainsString(
+			'The &quot;Self-hosted (PHP API)&quot; connection method is deprecated',
+			$this->render_php_mode_deprecation_notice()
+		);
+	}
+
+	public function test_show_php_mode_deprecation_notice_if_in_use_should_stay_silent_for_a_network_user_who_cannot_manage_sites() {
+		$this->network_activate_the_plugin();
+		\WP_Piwik::get_settings()->set_global_option( 'piwik_mode', 'php' );
+		$this->log_in_as_a_site_administrator_who_can_activate_plugins();
+
+		$this->assertSame( '', $this->render_php_mode_deprecation_notice() );
+	}
+
+	public function test_show_php_mode_deprecation_notice_if_in_use_should_warn_a_site_administrator_when_the_plugin_is_not_network_activated() {
+		$this->skip_unless_multisite();
+		\WP_Piwik::get_settings()->set_global_option( 'piwik_mode', 'php' );
+		$this->log_in_as_a_site_administrator_who_can_activate_plugins();
+
+		$this->assertStringContainsString(
+			'connection method is deprecated',
+			$this->render_php_mode_deprecation_notice()
+		);
+	}
+
 	private function render_deprecated_shortcode_notice() {
 		ob_start();
 		$GLOBALS['wp-piwik']->show_deprecated_shortcode_notice_if_in_use();
 		return ob_get_clean();
+	}
+
+	private function skip_unless_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Network mode requires a multisite installation.' );
+		}
+	}
+
+	private function network_activate_the_plugin() {
+		$this->skip_unless_multisite();
+
+		update_site_option( 'active_sitewide_plugins', array( 'wp-piwik/wp-piwik.php' => time() ) );
+
+		$this->assertTrue( $GLOBALS['wp-piwik']->is_network_mode(), 'precondition: the plugin runs in network mode' );
+	}
+
+	private function log_in_as_a_site_administrator_who_can_activate_plugins() {
+		update_site_option( 'menu_items', array( 'plugins' => 1 ) );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertTrue( current_user_can( 'activate_plugins' ), 'precondition: the user can activate plugins' );
+		$this->assertFalse( current_user_can( 'manage_sites' ), 'precondition: the user cannot manage the network' );
 	}
 
 	private function set_up_a_dismissal_that_ran_out() {

--- a/uninstall.php
+++ b/uninstall.php
@@ -105,6 +105,7 @@ function wp_matomo_uninstall() {
 		}
 		delete_site_option( 'wp-piwik-manually' );
 		delete_site_option( 'wp-piwik-notices' );
+		delete_site_option( 'wp-piwik-deprecated_shortcodes' );
 	}
 
 	foreach ( $settings as $key ) {
@@ -117,6 +118,7 @@ function wp_matomo_uninstall() {
 
 	delete_option( 'wp-piwik-manually' );
 	delete_option( 'wp-piwik-notices' );
+	delete_option( 'wp-piwik-deprecated_shortcodes' );
 
 	$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key LIKE 'wp-piwik-%'" );
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE '_transient_wp-piwik_%'" );


### PR DESCRIPTION
### Description

As title. They will be removed in the next major release.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
